### PR TITLE
Audit/recover: api.js helpers + unbreak frontend fetches + backend pkg

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "outreach-backend",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "nodemon server.js",
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.17.1",
+    "@google/generative-ai": "^0.3.0",
+    "apify-client": "^2.9.0",
+    "axios": "^1.6.5",
+    "better-sqlite3": "^11.7.0",
+    "cheerio": "^1.2.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "express-rate-limit": "^7.1.5",
+    "multer": "^2.1.1",
+    "node-cron": "^4.2.1",
+    "openai": "^4.26.0",
+    "pdf-parse": "^2.4.5",
+    "pino": "^10.3.1",
+    "pino-pretty": "^13.1.3",
+    "playwright": "^1.59.1",
+    "puppeteer": "^24.40.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.3"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -81,11 +81,22 @@ function RefreshBadge() {
   const [lastRefresh, setLastRefresh] = useState(null)
   const [refreshing, setRefreshing]   = useState(false)
   const [progress, setProgress]       = useState('')
-  const [now, setNow] = useState(Date.now())
+  // Lazy initializer is allowed for impure values (React calls it once on
+  // mount, not on every render). Direct `useState(Date.now())` is flagged
+  // by react-hooks/purity because it re-evaluates Date.now() every render.
+  const [now, setNow] = useState(() => Date.now())
 
   useEffect(() => {
     const timer = setInterval(() => setNow(Date.now()), 60000)
     return () => clearInterval(timer)
+  }, [])
+
+  // Pull the true last-refresh timestamp from the backend on mount (the badge
+  // previously rendered 'never' because setLastRefresh was never wired).
+  useEffect(() => {
+    api.jobs.lastRefresh()
+      .then(d => setLastRefresh(d?.lastRefresh || d?.timestamp || null))
+      .catch(() => {})
   }, [])
 
   // Bulk refresh isn't available on the serverless deployment; keep badge read-only.

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -7,26 +7,32 @@
 // (App.jsx / Login.jsx).
 // ─────────────────────────────────────────────────────────────────────────────
 
-const BASE = import.meta.env.VITE_API_URL || ''
-const API  = `${BASE}/api`
+const ENV = import.meta.env || {}
+const BASE = ENV.VITE_API_URL ? ENV.VITE_API_URL.replace(/\/$/, '') : ''
+export const API = `${BASE}/api`
+export const apiUrl = (path = '') => `${API}${path.startsWith('/') ? path : `/${path}`}`
+
+const isFormData = (body) => typeof FormData !== 'undefined' && body instanceof FormData
 
 async function apiCall(url, options = {}) {
   const init = {
     method: options.method || 'GET',
     headers: options.headers !== undefined
       ? options.headers
-      : (options.body instanceof FormData ? {} : { 'Content-Type': 'application/json' }),
+      : (isFormData(options.body) ? {} : { 'Content-Type': 'application/json' }),
   }
   if (options.body !== undefined) {
-    init.body = options.body instanceof FormData ? options.body : JSON.stringify(options.body)
+    init.body = isFormData(options.body) ? options.body : JSON.stringify(options.body)
   }
-  const res = await fetch(`${API}${url}`, init)
+  const res = await fetch(apiUrl(url), init)
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }))
     throw new Error(err.error || 'Request failed')
   }
   return res.json()
 }
+
+export const rawApiFetch = (url, options = {}) => fetch(apiUrl(url), options)
 
 const qs = (params) => {
   const entries = Object.entries(params || {}).filter(([, v]) => v !== undefined && v !== null && v !== '')
@@ -97,20 +103,38 @@ export const api = {
       pageSize: params.pageSize,
     })),
     dashboard:      () => apiCall('/unified/dashboard'),
+    allContacts:    (params = {}) => apiCall('/unified/all-contacts' + (
+      params instanceof URLSearchParams ? `?${params.toString()}` : qs(params)
+    )),
   },
 
   jobs: {
+    lastRefresh:  () => apiCall('/jobs/last-refresh'),
     search:       (q) => apiCall('/jobs/search' + qs({ q })),
     detail:       (id) => apiCall(`/jobs/${id}/detail`),
     roles:        (id) => apiCall(`/jobs/${id}/roles`),
     careersUrl:   (id) => apiCall(`/jobs/${id}/careers-url`),
     contacts:     (id) => apiCall(`/jobs/${id}/contacts`),
     scrapeRoles:  (id, roleType = 'intern') => apiCall(`/jobs/${id}/scrape-roles`, { method: 'POST', body: { roleType } }),
-    scrape:       (params) => apiCall('/companies/scrape', { method: 'POST', body: params }),
+    scrape:       (params) => apiCall('/jobs/scrape', { method: 'POST', body: params }),
     updateStatus: (id, status) => apiCall(`/jobs/${id}/status`, { method: 'PUT', body: { status } }),
-    findEmails:          () => Promise.reject(new Error('Use /jobs/:id/find-emails directly from route-specific UI')),
-    findEmailForContact: () => Promise.reject(new Error('Use /jobs/contacts/:contactId/find-email directly from route-specific UI')),
-    generate:            () => Promise.reject(new Error('Use /jobs/contacts/:contactId/generate directly from route-specific UI')),
+    findLinkedIn: (id) => apiCall(`/jobs/${id}/find-linkedin`, { method: 'POST', body: {} }),
+    findPeopleStream: (id) => apiUrl(`/jobs/${id}/find-people-stream`),
+    findEmails: (id, domain = null) => apiCall(`/jobs/${id}/find-emails`, {
+      method: 'POST',
+      body: domain ? { domain } : {},
+    }),
+    findEmailForContact: (contactId) => apiCall(`/jobs/contacts/${contactId}/find-email`, { method: 'POST', body: {} }),
+    generate: (contactId, type = 'email', extraContext = '') => apiCall(`/jobs/contacts/${contactId}/generate`, {
+      method: 'POST',
+      body: { type, extraContext },
+    }),
+    updateContact: (contactId, data) => apiCall(`/jobs/contacts/${contactId}`, { method: 'PUT', body: data }),
+    deleteContact: (contactId) => apiCall(`/jobs/contacts/${contactId}`, { method: 'DELETE' }),
+    scrapeLinkedInCompany: (id, linkedinUrl) => apiCall(`/jobs/${id}/scrape-linkedin-company`, {
+      method: 'POST',
+      body: { linkedinUrl },
+    }),
   },
 
   career: {
@@ -156,6 +180,7 @@ export const api = {
     getCompany:    (id) => apiCall(`/career/company/${id}`),
     updateCompany: (id, patch) => apiCall(`/career/company/${id}`, { method: 'PUT', body: patch }),
     scoreFit:      (id) => apiCall(`/career/company/${id}/score-fit`, { method: 'POST' }),
+    scoreFitUrl:   (id) => apiUrl(`/career/company/${id}/score-fit`),
 
     // ── Auto-apply ───────────────────────────────────────────────────────────
     autoApplyRun:           () => apiCall('/career/auto-apply/run', { method: 'POST' }),
@@ -170,11 +195,11 @@ export const api = {
       return apiCall(`/career/${companyId}/documents`, { method: 'POST', body: fd })
     },
     deleteDocument:   (companyId, docId) => apiCall(`/career/${companyId}/documents/${docId}`, { method: 'DELETE' }),
-    downloadDocument: (companyId, docId) => `${API}/career/${companyId}/documents/${docId}/download`,
+    downloadDocument: (companyId, docId) => apiUrl(`/career/${companyId}/documents/${docId}/download`),
 
     // ── Report / download URLs — backend renders the HTML/PDF directly ───────
-    reportHtmlUrl:  (id) => `${API}/career/evaluations/${id}/report.html`,
-    downloadUrl:    (id) => `${API}/career/download/${id}`,
+    reportHtmlUrl:  (id) => apiUrl(`/career/evaluations/${id}/report.html`),
+    downloadUrl:    (id) => apiUrl(`/career/download/${id}`),
     tailoredResume: (id) => apiCall(`/career/tailored-resume/${id}`, { method: 'POST' }),
   },
 

--- a/frontend/src/components/CareerOpsPage.jsx
+++ b/frontend/src/components/CareerOpsPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { api } from '../api'
 
 const APP_STATUS_LABELS = {
   interested:   { label:'Interested',    bg:'#eff6ff', color:'#2563eb' },
@@ -37,8 +38,7 @@ export default function CareerOpsPage() {
   const [filter, setFilter]     = useState('all')
 
   useEffect(() => {
-    fetch('/api/career/ranked')
-      .then(r => r.ok ? r.json() : { applications: [] })
+    api.career.ranked()
       .then(d => { setApplications(d.applications || []); setLoading(false) })
       .catch(e => { console.warn('Career ranked fetch error:', e); setLoading(false) })
   }, [])

--- a/frontend/src/components/CategoryView.jsx
+++ b/frontend/src/components/CategoryView.jsx
@@ -216,11 +216,21 @@ function YCCategoryView() {
   )
 }
 
-// ── Regular Category View ─────────────────────────────────────────────────────
+// ── Thin wrapper ──────────────────────────────────────────────────────────────
+// Routes to YC-specific view for the 'yc-startups' slug, otherwise the regular
+// category view. Splitting this way ensures the regular view's hooks run
+// unconditionally — previously the YC early-return sat between hook calls,
+// which violates React's rules-of-hooks and made the hook order unstable.
 export default function CategoryView() {
   const { name: encodedName } = useParams()
-  const navigate = useNavigate()
   const categoryName = decodeURIComponent(encodedName)
+  if (categoryName === 'yc-startups') return <YCCategoryView />
+  return <RegularCategoryView categoryName={categoryName} />
+}
+
+// ── Regular Category View ─────────────────────────────────────────────────────
+function RegularCategoryView({ categoryName }) {
+  const navigate = useNavigate()
 
   const [companies, setCompanies] = useState([])
   const [total, setTotal]         = useState(0)
@@ -233,8 +243,6 @@ export default function CategoryView() {
   const [scraping, setScraping]   = useState(null)
   const [scrapeMsg, setScrapeMsg] = useState(null)
   const debounce = useRef(null)
-
-  if (categoryName === 'yc-startups') return <YCCategoryView />
 
   const load = useCallback(async (pg = 0, q = search, src = source, st = status) => {
     setLoading(true)

--- a/frontend/src/components/CompanyDetail.jsx
+++ b/frontend/src/components/CompanyDetail.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
-import { api } from '../api'
+import { api, apiUrl } from '../api'
 import { AutoApplySetup } from './CareerOps'
 
 const CD_CSS = `
@@ -276,8 +276,7 @@ function OutreachTab({ company }) {
     setFindProgress(['Searching for decision makers…'])
     setFindResultMsg(null)
     try {
-      const url = `/api/jobs/${company.id}/find-people-stream`
-      const res = await fetch(url)
+      const res = await fetch(api.jobs.findPeopleStream(company.id))
       const reader = res.body.getReader()
       const dec = new TextDecoder()
       let buf = ''
@@ -1130,12 +1129,40 @@ function CareerOpsTab({ company, autoAnalyze, onAnalyzeDone }) {
     api.career.resume().then(d => setHasGlobalResume(!!d?.hasResume)).catch(() => {})
   }, [])
 
+  // Score-fit analysis — must be declared BEFORE the auto-trigger useEffect
+  // below so that effect doesn't reference it in the temporal dead zone.
+  // Wrapped in try/finally so that an early-return (parse error, API error)
+  // never leaves `analyzing` stuck at true, which previously required a full
+  // page refresh to recover.
+  const runAnalysis = useCallback(async () => {
+    if (!app?.job_title) return
+    setAnalyzing(true)
+    setEvalErr(null)
+    try {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), 95000)
+      const res  = await fetch(apiUrl(`/career/company/${company.id}/score-fit`), { method:'POST', signal: controller.signal })
+      clearTimeout(timer)
+      const text = await res.text()
+      let data
+      try { data = JSON.parse(text) } catch { setEvalErr(`Server error: ${text.slice(0, 200)}`); return }
+      if (data.error) { setEvalErr(data.error); return }
+      if (data.fit_score != null) setApp(prev => ({ ...prev, fit_score: data.fit_score }))
+      if (data.evalId)            setEvalId(data.evalId)
+      if (data.evaluation)        { setEval(data.evaluation); setRightPanel('eval') }
+    } catch (err) {
+      setEvalErr(err.name === 'AbortError' ? 'Analysis timed out. Gemini may be rate-limited — try again in a minute.' : err.message)
+    } finally {
+      setAnalyzing(false)
+    }
+  }, [app?.job_title, company.id])
+
   useEffect(() => {
     if (autoAnalyze && app?.job_title && (app?.resume_original_name || hasGlobalResume)) {
       onAnalyzeDone?.()
       runAnalysis()
     }
-  }, [autoAnalyze, app, hasGlobalResume])
+  }, [autoAnalyze, app, hasGlobalResume, runAnalysis, onAnalyzeDone])
 
   async function save() {
     if (!app) return
@@ -1155,7 +1182,7 @@ function CareerOpsTab({ company, autoAnalyze, onAnalyzeDone }) {
     try {
       const fd = new FormData()
       fd.append('resume', file)
-      const res = await fetch(`/api/companies/${company.id}/career-ops/resume`, { method:'POST', body: fd })
+      const res = await fetch(apiUrl(`/companies/${company.id}/career-ops/resume`), { method:'POST', body: fd })
       const data = await res.json()
       if (data.resume && data.application) {
         setApp(data.application)
@@ -1172,33 +1199,11 @@ function CareerOpsTab({ company, autoAnalyze, onAnalyzeDone }) {
   async function deleteResume() {
     setResumeDel(true)
     try {
-      await fetch(`/api/companies/${company.id}/career-ops/resume`, { method:'DELETE' })
+      await fetch(apiUrl(`/companies/${company.id}/career-ops/resume`), { method:'DELETE' })
       setApp(prev => ({ ...prev, resume_path:null, resume_original_name:null, resume_size:null }))
       setEval(null)
     } catch (_) {}
     setResumeDel(false)
-  }
-
-  async function runAnalysis() {
-    if (!app?.job_title) return
-    setAnalyzing(true)
-    setEvalErr(null)
-    try {
-      const controller = new AbortController()
-      const timer = setTimeout(() => controller.abort(), 95000)
-      const res  = await fetch(`/api/career/company/${company.id}/score-fit`, { method:'POST', signal: controller.signal })
-      clearTimeout(timer)
-      const text = await res.text()
-      let data
-      try { data = JSON.parse(text) } catch (_) { setEvalErr(`Server error: ${text.slice(0, 200)}`); return }
-      if (data.error) { setEvalErr(data.error); return }
-      if (data.fit_score != null) setApp(prev => ({ ...prev, fit_score: data.fit_score }))
-      if (data.evalId)            setEvalId(data.evalId)
-      if (data.evaluation)        { setEval(data.evaluation); setRightPanel('eval') }
-    } catch (err) {
-      setEvalErr(err.name === 'AbortError' ? 'Analysis timed out. Gemini may be rate-limited — try again in a minute.' : err.message)
-    }
-    setAnalyzing(false)
   }
 
   async function generatePDF() {
@@ -1208,7 +1213,7 @@ function CareerOpsTab({ company, autoAnalyze, onAnalyzeDone }) {
     try {
       const data = await api.career.tailoredResume(evalId)
       if (data.error) { setPdfError(data.error); return }
-      window.open(`/api/career/download/${evalId}`, '_blank')
+      window.open(api.career.downloadUrl(evalId), '_blank')
     } catch (err) {
       setPdfError(err.message)
     }

--- a/frontend/src/components/CompanyDetail.jsx
+++ b/frontend/src/components/CompanyDetail.jsx
@@ -555,7 +555,7 @@ function JobScraperTab({ company, onTabSwitch }) {
       try {
         const [appData, globalResume] = await Promise.all([
           api.career.getCompany(company.id),
-          fetch('/api/career/resume').then(r => r.json()).catch(() => ({})),
+          api.career.resume().catch(() => ({})),
         ])
         hasResume = !!appData?.resume_original_name || !!globalResume?.hasResume
       } catch (_) {}
@@ -1127,7 +1127,7 @@ function CareerOpsTab({ company, autoAnalyze, onAnalyzeDone }) {
   // Works with both per-company resume (resume_original_name) and globally uploaded resume (hasGlobalResume)
   const [hasGlobalResume, setHasGlobalResume] = useState(false)
   useEffect(() => {
-    fetch('/api/career/resume').then(r => r.json()).then(d => setHasGlobalResume(!!d?.hasResume)).catch(() => {})
+    api.career.resume().then(d => setHasGlobalResume(!!d?.hasResume)).catch(() => {})
   }, [])
 
   useEffect(() => {

--- a/package.json
+++ b/package.json
@@ -5,14 +5,15 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "install:all": "npm install && npm install --prefix frontend",
-    "dev": "npm run dev --prefix frontend",
+    "install:all": "npm install && npm install --prefix frontend && npm install --prefix backend",
+    "dev": "concurrently -n api,web -c cyan,magenta \"npm run dev --prefix backend\" \"npm run dev --prefix frontend\"",
     "dev:frontend": "npm run dev --prefix frontend",
-    "dev:api": "vercel dev",
+    "dev:api": "npm run dev --prefix backend",
     "build:frontend": "npm run build --prefix frontend",
     "build": "npm install --prefix frontend && npm run build --prefix frontend",
     "lint": "npm run lint --prefix frontend",
     "preview": "npm run preview --prefix frontend",
+    "test": "node --test tests/",
     "setup": "bash setup.sh"
   },
   "dependencies": {

--- a/tests/api-client.test.mjs
+++ b/tests/api-client.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { api, apiUrl } from '../frontend/src/api.js'
+
+function mockJsonFetch(check, payload = {}) {
+  globalThis.fetch = async (url, init = {}) => {
+    check(url, init)
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}
+
+test('apiUrl builds local proxy URLs by default', () => {
+  assert.equal(apiUrl('/health'), '/api/health')
+  assert.equal(apiUrl('career/resume'), '/api/career/resume')
+})
+
+test('job contact endpoints use the backend routes expected by the UI', async () => {
+  mockJsonFetch((url, init) => {
+    assert.equal(url, '/api/jobs/contacts/7/generate')
+    assert.equal(init.method, 'POST')
+    assert.deepEqual(JSON.parse(init.body), { type: 'linkedin', extraContext: 'met at Grace Hopper' })
+  }, { message: 'hello' })
+  await api.jobs.generate(7, 'linkedin', 'met at Grace Hopper')
+
+  mockJsonFetch((url, init) => {
+    assert.equal(url, '/api/jobs/contacts/7')
+    assert.equal(init.method, 'PUT')
+    assert.deepEqual(JSON.parse(init.body), { status: 'sent' })
+  }, { id: 7, status: 'sent' })
+  await api.jobs.updateContact(7, { status: 'sent' })
+})
+
+test('email finder endpoints post to canonical jobs routes', async () => {
+  mockJsonFetch((url, init) => {
+    assert.equal(url, '/api/jobs/42/find-emails')
+    assert.equal(init.method, 'POST')
+    assert.deepEqual(JSON.parse(init.body), { domain: 'example.com' })
+  }, { added: 1 })
+  await api.jobs.findEmails(42, 'example.com')
+
+  mockJsonFetch((url, init) => {
+    assert.equal(url, '/api/jobs/contacts/11/find-email')
+    assert.equal(init.method, 'POST')
+    assert.deepEqual(JSON.parse(init.body), {})
+  }, { email: 'person@example.com' })
+  await api.jobs.findEmailForContact(11)
+})
+
+test('raw URL helpers respect the shared API base', () => {
+  const params = new URLSearchParams({ limit: '500', hasEmail: 'true' })
+  mockJsonFetch((url, init) => {
+    assert.equal(url, '/api/unified/all-contacts?limit=500&hasEmail=true')
+    assert.equal(init.method, 'GET')
+  }, { contacts: [] })
+  return api.unified.allContacts(params)
+})
+
+test('career document/report URLs use the shared API base', () => {
+  assert.equal(api.career.downloadUrl(5), '/api/career/download/5')
+  assert.equal(api.career.reportHtmlUrl(5), '/api/career/evaluations/5/report.html')
+  assert.equal(api.career.scoreFitUrl(9), '/api/career/company/9/score-fit')
+})


### PR DESCRIPTION
## Summary — two commits

### 1. Lost-work recovery (`2fe6e6b`)
Reconstructs the audit-fix work that was discarded when I (agent) ran `git reset --hard` against a dirty tree. Rebuilt from the surviving `tests/api-client.test.mjs` spec + prior system-reminder snippets.

- **`frontend/src/api.js`** — `ENV` destructure, `BASE` with trailing-slash strip, `API`, `apiUrl(path)` helper (handles both `/path` and `path`), `isFormData` helper, `rawApiFetch` export.
- **`jobs.*` canonical contact routes** — `lastRefresh`, `findLinkedIn`, `findPeopleStream` (returns URL for SSE), `findEmails(id, domain)`, `findEmailForContact`, `generate(contactId, type, extraContext)`, `updateContact`, `deleteContact`, `scrapeLinkedInCompany`.
- **`unified.allContacts(params)`** — accepts URLSearchParams OR plain object.
- **`career.*`** — `scoreFitUrl` helper; `downloadUrl`/`reportHtmlUrl`/`downloadDocument` go through `apiUrl()` so they respect `VITE_API_URL`.
- **3 hard-coded `fetch('/api/...')`** in `CompanyDetail.jsx` + `CareerOpsPage.jsx` replaced with `api.*` helpers.
- **Root `package.json`** — `dev:api` was `vercel dev` (dead since Phase 6); re-point to `npm run dev --prefix backend`. `dev` now runs backend + frontend concurrently. Add `test` script.
- **`backend/package.json`** — workspace manifest (was missing, so backend couldn't be installed/run independently).
- **`tests/api-client.test.mjs`** — your surviving spec, covers 5 critical flows.

### 2. Audit/lint-driven fixes (`38f2fe7`)
Applied after running ESLint, which pinpointed the 3 issues from the original audit description:

- **CategoryView hook order** — `useCallback`/`useEffect` were called after a conditional `if (categoryName === 'yc-startups') return <YCCategoryView />`. Split into a thin wrapper (`CategoryView` default export) that picks YC vs Regular, and `RegularCategoryView` whose hooks run unconditionally. Fixes `react-hooks/rules-of-hooks` at 239/255.
- **App.jsx RefreshBadge** — wire `setLastRefresh` via `api.jobs.lastRefresh()` on mount (state was declared but never assigned, badge always read "never"). `useState(Date.now())` → `useState(() => Date.now())` lazy initializer; fixes `react-hooks/purity`.
- **CompanyDetail `runAnalysis`** — (a) hoist above its consumer `useEffect` so it's no longer referenced before declaration; (b) convert to `useCallback` with `[app?.job_title, company.id]` deps; (c) wrap body in `try/finally` so `setAnalyzing(false)` always runs. Previously a JSON parse failure would leave the spinner stuck until full page reload.
- **Also while files were open**: 6 remaining hard-coded `fetch('/api/...')` in `CompanyDetail.jsx` → `api.jobs.findPeopleStream`, `api.career.resume`, `api.career.downloadUrl`, or `apiUrl()` wrapped.

## Test plan
- [x] `node --test tests/api-client.test.mjs` → **5/5 pass**
- [x] `npm run build --prefix frontend` → **clean** (80 modules, 0 errors)
- [x] `grep "fetch('/api" frontend/src/` → 0 hits (excluding api.phase-5.js stale template + 3 remaining in JobDashboard/OutreachPage/CareerOpsPage which are out of scope for this audit item)
- [x] Lint errors on the 3 audit-targeted files: **0** (down from 6 rule-of-hooks + purity + use-before-define)
- [x] Total frontend lint: 52→47 errors (my targeted reductions)