### PR TITLE
audit/docs: align README with current architecture + deprecate stale guides

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,6 +1,14 @@
 # OutreachOS Deployment Guide
 
-**Architecture:** React Frontend (Vercel) + Vercel Serverless Functions + Supabase PostgreSQL
+> ⚠️ **DEPRECATED — pre-Phase-4 document.** This guide describes a
+> Vercel-Serverless + Railway + SQLite architecture that is no longer in
+> use. As of 2026-04-24 the backend runs on an Oracle Cloud Always Free
+> VM against Supabase Postgres, and the Vercel `api/` directory has been
+> retired. See [PLAN.txt](PLAN.txt) and the "Architecture" section of
+> [README.md](README.md) for the current setup. Preserved for historical
+> context only — **do not follow these steps on a fresh deploy.**
+
+**Architecture (historical):** React Frontend (Vercel) + Vercel Serverless Functions + Supabase PostgreSQL
 
 ---
 

--- a/FINAL_SUMMARY.md
+++ b/FINAL_SUMMARY.md
@@ -1,5 +1,10 @@
 # OutreachOS - Final Summary & Deployment Status
 
+> ⚠️ **Historical snapshot — pre-Phase-4.** This summary describes the
+> Vercel-serverless + SQLite era (retired 2026-04-24). For current
+> state, see [README.md](README.md) and [PLAN.txt](PLAN.txt). Preserved
+> for context only.
+
 ## ✅ What Was Completed
 
 ### Phase 1: Code Quality (127 → 53 ESLint errors -58%)

--- a/GITHUB_PUSH.md
+++ b/GITHUB_PUSH.md
@@ -1,5 +1,11 @@
 # GitHub Push & Vercel Deployment Instructions
 
+> ⚠️ **Historical — pre-Phase-4 initial push guide.** The repo is
+> already published at https://github.com/Sravya1802/outreach-os and
+> the Vercel-only deployment path described here is no longer accurate
+> (backend now lives on Oracle Cloud). See [README.md](README.md) and
+> [PLAN.txt](PLAN.txt). Preserved for historical reference only.
+
 ## Step 1: Create GitHub Repository
 
 1. Go to https://github.com/new

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,5 +1,11 @@
 # OutreachOS Quick Start
 
+> ⚠️ **DEPRECATED — pre-Phase-4 document.** This walkthrough points at
+> Vercel Serverless + SQLite, which was retired in Phase 6. Use the
+> "Local Development" section of [README.md](README.md) instead — it
+> reflects the current `npm run dev` → backend+frontend concurrent setup
+> against Supabase Postgres. Preserved for historical context only.
+
 Get your job search automation platform running in **20 minutes**.
 
 ## 🚀 The Fast Path

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - **Smart categorization** — 23 industry categories auto-applied
 - **Contact enrichment** — Apollo.io + Hunter.io email finding
 
-### 📋 Application Pipeline  
+### 📋 Application Pipeline
 - **Kanban board** — Visualize progress (evaluated → applied → offered)
 - **Auto-apply** — Playwright form-filling for Greenhouse, Lever, Ashby
 - **Resume tailoring** — AI keyword injection + PDF generation
@@ -25,90 +25,122 @@
 
 ---
 
-## 🚀 Quick Start
+## 🏗️ Architecture
+
+Production runs across three free-tier services:
+
+```
+┌──────────────────────────┐   HTTPS    ┌───────────────────────────┐
+│ Vercel (frontend)        │ ─────────▶ │ Oracle Cloud Always Free  │
+│ outreach-jt.vercel.app   │            │ VM, Ubuntu 22.04 ARM      │
+│ React 19 + Vite SPA      │            │ Express + pm2 + nginx     │
+└──────────────────────────┘            │ Playwright + Let's Encrypt│
+                                         └─────────────┬─────────────┘
+                                                       │ pg pool
+                                                       ▼
+                                         ┌───────────────────────────┐
+                                         │ Supabase Free             │
+                                         │ Postgres 17 + Storage     │
+                                         │ + Auth (shared workspace) │
+                                         └───────────────────────────┘
+```
+
+- **Frontend**: React 19 + Vite + Tailwind. Hosted on Vercel (static). Uses `VITE_API_URL` to point at the backend.
+- **Backend**: Express.js + node-postgres. Hosted on an Oracle Cloud Always Free ARM VM (`outreach-jt.duckdns.org`). Playwright for auto-apply. Puppeteer for PDF generation.
+- **Database**: Supabase Postgres (reached via the IPv4 session pooler — Oracle Free VMs don't have IPv6).
+- **Auth**: Supabase Auth (frontend `supabase.auth`); backend is currently unauthenticated at the HTTP layer — if you're hardening this for multi-user, see the "Known gaps" section below.
+
+**Cost**: $0/month, permanent. See [PLAN.txt](PLAN.txt) for the full migration record.
+
+---
+
+## 🚀 Local Development
 
 ```bash
-# Clone & setup
-git clone https://github.com/yourusername/outreacha-os.git
-cd outreacha-os
-bash setup.sh
+# Clone + install both workspaces
+git clone https://github.com/Sravya1802/outreach-os.git
+cd outreach-os
+npm run install:all
 
-# Update .env with API keys
-cp .env.example .env
-# Edit .env: Add GEMINI_API_KEY (free tier available)
+# Configure env — root .env is used by the backend
+cp .env.example .env  # if you have an example; otherwise author it from scratch
+# Required: OPENAI_API_KEY (or GEMINI_API_KEY) + DATABASE_URL (Supabase session pooler URI)
 
-# Start development
-cd frontend && npm run dev  # Terminal 1
-cd backend && npm run dev   # Terminal 2
+# Run backend + frontend concurrently
+npm run dev
+# → backend on :3001 (reads DATABASE_URL)
+# → frontend on :5173 (proxies /api to backend when VITE_API_URL is unset)
 
-# Open http://localhost:5173
+# Or run individually
+npm run dev:api       # backend only
+npm run dev:frontend  # frontend only
+```
+
+### Required env vars
+
+**Backend** (`/.env` or `backend/.env`):
+```
+DATABASE_URL=postgresql://postgres.<ref>:<password>@aws-1-<region>.pooler.supabase.com:5432/postgres
+AI_PROVIDER=openai
+OPENAI_API_KEY=...
+# Optional
+FRONTEND_ORIGIN=https://outreach-jt.vercel.app
+CORS_ORIGINS=https://preview-a.vercel.app,https://preview-b.vercel.app  # comma-separated
+APIFY_API_TOKEN=... SERPER_API_KEY=... APOLLO_API_KEY=... HUNTER_API_KEY=...
+LINKEDIN_SESSION_COOKIE=... PROSPEO_API_KEY=...
+```
+
+**Frontend** (Vercel project settings → Environment Variables, OR `frontend/.env.local`):
+```
+VITE_SUPABASE_URL=https://<ref>.supabase.co
+VITE_SUPABASE_ANON_KEY=...
+VITE_API_URL=https://outreach-jt.duckdns.org  # production only — leave unset for local dev
 ```
 
 ---
 
-## 🔧 Environment Setup
+## 🧪 Tests
 
-**Required:**
-```
-PORT=3001
-AI_PROVIDER=gemini
-GEMINI_API_KEY=your_key  # Free tier available
-```
-
-**Optional (recommended):**
-```
-ANTHROPIC_API_KEY=your_key
-APOLLO_API_KEY=your_key
-APIFY_API_TOKEN=your_token
-HUNTER_API_KEY=your_key
-LINKEDIN_SESSION_COOKIE=li_at
-```
-
----
-
-## 🏗️ Tech Stack
-
-- **Frontend**: React 19 + Vite + Tailwind
-- **Backend**: Express.js + SQLite
-- **AI**: Gemini, Claude, GPT-4o
-- **Automation**: Playwright (form filling), Puppeteer (PDF generation)
-- **Integrations**: Apify, Apollo.io, Hunter.io
-
----
-
-## 📊 Recent Improvements
-
-- ✅ Fixed 58% of ESLint errors (127 → 53)
-- ✅ Removed 11 dead components
-- ✅ Extracted shared utilities
-- ✅ Added 8 database performance indexes
-- ✅ Integrated Pino logging
-- ✅ Input validation middleware ready
-- ✅ Auto-apply fully functional
-
-See **IMPROVEMENTS.md** for details.
-
----
-
-## 🚢 Deployment
-
-### Frontend (Vercel - Free)
 ```bash
-# 1. Push to GitHub
-# 2. Connect at vercel.com/new
-# 3. Select frontend directory
-# 4. Deploy (auto on every push)
+npm test  # runs node --test against tests/ (currently: tests/api-client.test.mjs)
 ```
 
-### Backend (Railway ~$7/month)
-See **DEPLOYMENT.md** for Railway, Heroku, Fly.io setup.
+Frontend build check:
+```bash
+npm run build --prefix frontend
+```
+
+Lint:
+```bash
+npm run lint --prefix frontend
+```
+
+---
+
+## 📚 Docs
+
+| File | Scope |
+|---|---|
+| **[PLAN.txt](PLAN.txt)** | Canonical migration plan (Vercel → Oracle + Supabase). Read this first for "how did we get here". |
+| [PLAN-B.txt](PLAN-B.txt) | Fallback deployment plan (Google Cloud Run), unused. |
+| [ORACLE-SETUP.txt](ORACLE-SETUP.txt) | Step-by-step Oracle Cloud account + VM bootstrap (Phase 1). |
+| [PHASE-2-CHEATSHEET.txt](PHASE-2-CHEATSHEET.txt) | `oracle-setup.sh` installer walkthrough (Phase 2). |
+| [PHASE-7-TEST-PLAN.txt](PHASE-7-TEST-PLAN.txt) | 40-feature manual end-to-end test checklist. |
+| [SUPABASE_SETUP.md](SUPABASE_SETUP.md) | Supabase project creation + schema apply. |
+| `supabase/migrations/*.sql` | Schema of record. Apply via the Supabase SQL editor. |
+| [IMPROVEMENTS.md](IMPROVEMENTS.md) | Historical refactor notes (pre-Phase-4). |
+| [BUG_REPORT.md](BUG_REPORT.md), [DEPLOYMENT.md](DEPLOYMENT.md), [FINAL_SUMMARY.md](FINAL_SUMMARY.md), [GITHUB_PUSH.md](GITHUB_PUSH.md), [QUICKSTART.md](QUICKSTART.md) | Historical — written before the Oracle migration. They describe a Vercel-serverless + SQLite + Railway architecture that **no longer applies**. Each has a deprecation banner. Preserved for context only. |
+
+---
+
+## ⚠️ Known gaps
+
+- **Backend is unauthenticated at the HTTP layer.** `/api/*` routes are open to anyone who can reach `outreach-jt.duckdns.org`. Supabase auth protects the frontend UI, but direct `curl` against the backend can mutate data, trigger scraping, and call auto-apply. If you're deploying for anyone outside a small trusted group, add JWT verification middleware (`supabase.auth.getUser(token)` server-side) before shipping.
+- **Multi-user isolation.** The 002 schema declares RLS policies for `authenticated` role, but the backend uses the Supabase service-role key, which bypasses RLS. The app is designed as a 4-user shared workspace — every user sees every other user's data. Per-user scoping would require adding `user_id` columns and scoping every query.
+- **PII in git history.** Earlier commits tracked tailored-resume PDFs under `backend/output/`. Current commits untrack them, but history still contains them. The GitHub repo is currently public — if you don't want those PDFs indexable, either run `git filter-repo` to purge, or mark the repo private.
 
 ---
 
 ## 📄 License
 
 MIT © 2026 — Free to use and modify
-
----
-
-**Pro Tip:** Evaluate jobs with AI first (A-graded roles have 3x better response rates), then auto-apply to top candidates.


### PR DESCRIPTION
## Summary
Addresses the **Medium, not fixed** audit item: deployment docs conflict between Vercel serverless, Railway, Oracle VM, SQLite, and Supabase.

### README.md — rewritten to reflect reality
- Tech stack now says Express + node-postgres, not SQLite.
- Architecture section with a diagram of the live Vercel → Oracle VM → Supabase flow.
- Required env vars: `DATABASE_URL`, `VITE_API_URL`, new `CORS_ORIGINS` multi-origin option.
- Local dev matches the fixed root scripts (`npm run dev` runs backend+frontend concurrently).
- Docs map pointing readers at the authoritative file per topic.
- **Known-gaps section** explicitly flags (a) the unauthenticated backend, (b) shared-workspace RLS posture, (c) PII-in-git-history — so anyone forking this doesn't get blindsided.

### Deprecation banners on 4 pre-Phase-4 docs
Each gets a banner pointing to `README.md` / `PLAN.txt`. Files kept for historical context, not deleted.

- `DEPLOYMENT.md` — Vercel-serverless + Railway architecture, no longer applies
- `QUICKSTART.md` — SQLite-era 20-min walkthrough
- `FINAL_SUMMARY.md` — old phase-1 snapshot
- `GITHUB_PUSH.md` — initial-push walkthrough (repo is already published)

### Intentionally left alone
- `PLAN.txt` / `PLAN-B.txt` / `ORACLE-SETUP.txt` / `PHASE-2-CHEATSHEET.txt` / `PHASE-7-TEST-PLAN.txt` / `SUPABASE_SETUP.md` / `IMPROVEMENTS.md` / `BUG_REPORT.md` — these are either still authoritative (phase plans, phase cheatsheets) or clearly-labeled historical docs where a banner would be noise.

## Test plan
- [x] Docs-only change — no code touched, no build impact
- [ ] You read through README.md end-to-end and tell me if the "Known gaps" framing is right (particularly the tone — should any of those be softened or removed?)
- [ ] Confirm the deprecation banners don't delete info you still need