### PR TITLE
Phase C: IA refactor — DISCOVER / APPLY / OUTREACH + Auto Apply page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,8 @@ import CareerOpsPage    from './components/CareerOpsPage'
 import CareerOps        from './components/CareerOps'
 import ApplicationPipeline from './components/ApplicationPipeline'
 import JobDashboard     from './components/JobDashboard'
+import AutoApplyPage    from './components/AutoApplyPage'
+import TemplatesPage    from './components/TemplatesPage'
 import Login            from './components/Login'
 
 
@@ -218,45 +220,57 @@ export default function App() {
         {/* Nav */}
         <nav style={{ flex:1, padding:'4px 10px', overflowY:'auto' }}>
 
-          {/* MAIN section */}
-          {sectionLabel('Main')}
-
+          {/* DASHBOARD (top-level, no section heading) */}
           <NavLink to="/dashboard" end style={({ isActive }) => navStyle(isActive)}>
             <span style={{ flex:1 }}>Dashboard</span>
           </NavLink>
-
-          <NavLink to="/companies" end style={({ isActive }) => navStyle(isActive)}>
-            <span style={{ flex:1 }}>Companies</span>
-            <NavBadge n={stats?.totalCompanies} />
-          </NavLink>
-
-          <NavLink to="/pipeline" style={({ isActive }) => navStyle(isActive)}>
-            <span style={{ flex:1 }}>Pipeline</span>
-          </NavLink>
-
-          {/* TOOLS section */}
-          {sectionLabel('Tools')}
 
           <NavLink to="/job-dashboard" style={({ isActive }) => navStyle(isActive)}>
             <span style={{ flex:1 }}>Job Dashboard</span>
           </NavLink>
 
-          <NavLink to="/outreach" style={({ isActive }) => navStyle(isActive)}>
-            <span style={{ flex:1 }}>Outreach</span>
-            <NavBadge n={stats?.totalContacts} />
+          {/* DISCOVER — find roles + score them */}
+          {sectionLabel('Discover')}
+
+          <NavLink to="/discover/companies" style={({ isActive }) => navStyle(isActive)}>
+            <span style={{ flex:1 }}>Companies</span>
+            <NavBadge n={stats?.totalCompanies} />
           </NavLink>
 
-          <NavLink to="/scraper" style={({ isActive }) => navStyle(isActive)}>
+          <NavLink to="/discover/scraper" style={({ isActive }) => navStyle(isActive)}>
             <span style={{ flex:1 }}>Job Scraper</span>
           </NavLink>
 
-          <NavLink to="/career-ops" style={({ isActive }) => navStyle(isActive)}>
-            <span style={{ flex:1 }}>Role Eligibility Info</span>
+          <NavLink to="/discover/evaluate" style={({ isActive }) => navStyle(isActive)}>
+            <span style={{ flex:1 }}>Evaluate a Role</span>
+          </NavLink>
+
+          {/* APPLY — decide, apply, track */}
+          {sectionLabel('Apply')}
+
+          <NavLink to="/apply/auto-apply" style={({ isActive }) => navStyle(isActive)}>
+            <span style={{ flex:1 }}>Auto Apply</span>
+          </NavLink>
+
+          <NavLink to="/apply/pipeline" style={({ isActive }) => navStyle(isActive)}>
+            <span style={{ flex:1 }}>Pipeline</span>
+          </NavLink>
+
+          <NavLink to="/apply/ranked" style={({ isActive }) => navStyle(isActive)}>
+            <span style={{ flex:1 }}>Ranked Roles</span>
             <NavBadge n={stats?.totalApplications} />
           </NavLink>
 
-          <NavLink to="/career-ops-workflow" style={({ isActive }) => navStyle(isActive)}>
-            <span style={{ flex:1 }}>Career Ops</span>
+          {/* OUTREACH — cold reach-outs */}
+          {sectionLabel('Outreach')}
+
+          <NavLink to="/outreach/messages" style={({ isActive }) => navStyle(isActive)}>
+            <span style={{ flex:1 }}>Messages</span>
+            <NavBadge n={stats?.totalContacts} />
+          </NavLink>
+
+          <NavLink to="/outreach/templates" style={({ isActive }) => navStyle(isActive)}>
+            <span style={{ flex:1 }}>Templates</span>
           </NavLink>
 
         </nav>
@@ -300,19 +314,41 @@ export default function App() {
       {/* ── Main content ── */}
       <main style={{ flex:1, overflow:'hidden', display:'flex', flexDirection:'column' }}>
         <Routes>
-          <Route path="/"                  element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard"         element={<DashboardPage onStatsChange={setStats} />} />
-          <Route path="/companies"         element={<CompanyDashboard onStatsChange={setStats} />} />
+          {/* Top-level */}
+          <Route path="/"               element={<Navigate to="/dashboard" replace />} />
+          <Route path="/dashboard"      element={<DashboardPage onStatsChange={setStats} />} />
+          <Route path="/job-dashboard"  element={<JobDashboard />} />
+
+          {/* DISCOVER section */}
+          <Route path="/discover/companies"  element={<CompanyDashboard onStatsChange={setStats} />} />
+          <Route path="/discover/scraper"    element={<ScraperPage />} />
+          <Route path="/discover/evaluate"   element={<CareerOps />} />
+
+          {/* APPLY section */}
+          <Route path="/apply/auto-apply"    element={<AutoApplyPage />} />
+          <Route path="/apply/pipeline"      element={<ApplicationPipeline />} />
+          <Route path="/apply/ranked"        element={<CareerOpsPage />} />
+
+          {/* OUTREACH section */}
+          <Route path="/outreach/messages"   element={<OutreachPage />} />
+          <Route path="/outreach/templates"  element={<TemplatesPage />} />
+
+          {/* Detail/utility routes (used by deep links from cards/buttons) */}
           <Route path="/category/:name"    element={<CategoryView />} />
           <Route path="/company/:id"       element={<CompanyDetail />} />
-          <Route path="/pipeline"          element={<ApplicationPipeline />} />
-          <Route path="/outreach"          element={<OutreachPage />} />
-          <Route path="/scraper"           element={<ScraperPage />} />
-          <Route path="/career-ops"        element={<CareerOpsPage />} />
-          <Route path="/career-ops-workflow" element={<CareerOps />} />
-          <Route path="/job-dashboard"     element={<JobDashboard />} />
+
+          {/* Settings */}
           <Route path="/settings"          element={<Settings name={profileName} setName={setProfileName} aiProvider={aiProvider} setAiProvider={setAiProvider} onSignOut={signOut} userEmail={session.user?.email} />} />
-          <Route path="*"                  element={<Navigate to="/dashboard" replace />} />
+
+          {/* Legacy redirects — keep bookmarks alive after the IA refactor */}
+          <Route path="/companies"            element={<Navigate to="/discover/companies" replace />} />
+          <Route path="/scraper"              element={<Navigate to="/discover/scraper" replace />} />
+          <Route path="/career-ops-workflow"  element={<Navigate to="/discover/evaluate" replace />} />
+          <Route path="/pipeline"             element={<Navigate to="/apply/pipeline" replace />} />
+          <Route path="/career-ops"           element={<Navigate to="/apply/ranked" replace />} />
+          <Route path="/outreach"             element={<Navigate to="/outreach/messages" replace />} />
+
+          <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Routes>
       </main>
     </div>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -226,6 +226,16 @@ export const api = {
     autoApplyDirect:        (body) => apiCall('/career/auto-apply-direct',        { method: 'POST', body }),
     autoApplyResumePreview: (jobUrls) => apiCall('/career/auto-apply/resume-preview', { method: 'POST', body: { jobUrls } }),
 
+    // ── Bulk queue (slider in Auto Apply → Queue tab) ────────────────────────
+    bulkQueuePreview: (params) => apiCall('/career/bulk-queue/preview' + (
+      params instanceof URLSearchParams ? `?${params.toString()}` : (
+        params && (params.minGrade || params.minScore != null)
+          ? '?' + new URLSearchParams(Object.fromEntries(Object.entries(params).filter(([, v]) => v !== '' && v != null))).toString()
+          : ''
+      )
+    )),
+    bulkQueue:        (body) => apiCall('/career/bulk-queue', { method: 'POST', body }),
+
     // ── Company documents ────────────────────────────────────────────────────
     documents:        (companyId) => apiCall(`/career/${companyId}/documents`),
     uploadDocument:   async (companyId, file) => {

--- a/frontend/src/components/AutoApplyPage.jsx
+++ b/frontend/src/components/AutoApplyPage.jsx
@@ -1,0 +1,261 @@
+import { useState, useEffect } from 'react'
+import { api } from '../api'
+import { AutoApplySetup } from './CareerOps'
+
+const TABS = [
+  { id: 'setup',          label: '⚙ Setup',          desc: 'Profile + resume library used to fill applications' },
+  { id: 'queue',          label: '📋 Queue',         desc: 'Bulk-queue evaluations + run the worker' },
+  { id: 'resume-folder',  label: '📁 Resume Folder', desc: 'Role-archetype PDFs: AIML / SWE / DS / DevOps / full stack / startup' },
+  { id: 'history',        label: '📜 History',       desc: 'Past auto-apply runs and outcomes' },
+]
+
+const GRADE_ORDER = ['A', 'B', 'C', 'D', 'F']
+
+export default function AutoApplyPage() {
+  const [tab, setTab] = useState('setup')
+  return (
+    <div style={{ flex:1, overflowY:'auto', background:'#f8fafc' }}>
+      {/* Header */}
+      <div style={{ padding:'24px 40px 0', background:'#fff', borderBottom:'1px solid #e2e8f0' }}>
+        <h1 style={{ fontSize:22, fontWeight:800, color:'#0f172a', margin:'0 0 4px' }}>Auto Apply</h1>
+        <p style={{ fontSize:13, color:'#64748b', margin:'0 0 18px' }}>
+          Submit applications automatically against Greenhouse, Lever, and Ashby portals using your tailored resume + profile.
+        </p>
+        <div style={{ display:'flex', gap:0 }}>
+          {TABS.map(t => (
+            <button key={t.id} onClick={() => setTab(t.id)}
+              style={{ padding:'10px 22px', fontSize:13, fontWeight:700, background:'transparent',
+                color: tab === t.id ? '#4f46e5' : '#64748b',
+                border:'none', borderBottom: tab === t.id ? '3px solid #4f46e5' : '3px solid transparent',
+                cursor:'pointer' }}>
+              {t.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ padding:'24px 40px', maxWidth:1200, margin:'0 auto' }}>
+        <div style={{ fontSize:12, color:'#94a3b8', marginBottom:18 }}>{TABS.find(t => t.id === tab)?.desc}</div>
+        {tab === 'setup'         && <SetupTab />}
+        {tab === 'queue'         && <QueueTab />}
+        {tab === 'resume-folder' && <ResumeFolderTab />}
+        {tab === 'history'       && <HistoryTab />}
+      </div>
+    </div>
+  )
+}
+
+function SetupTab() {
+  // Reuse the existing AutoApplySetup component from CareerOps so the same
+  // profile editor + resume library + run-queue button works here.
+  return (
+    <div style={{ background:'#fff', border:'1px solid #e2e8f0', borderRadius:14, padding:'24px 28px' }}>
+      <AutoApplySetup />
+    </div>
+  )
+}
+
+function QueueTab() {
+  const [minGrade, setMinGrade] = useState('B')
+  const [minScore, setMinScore] = useState(70)
+  const [preview, setPreview]   = useState({ count: 0, rows: [] })
+  const [loadingPreview, setLP] = useState(false)
+  const [queuing, setQueuing]   = useState(false)
+  const [running, setRunning]   = useState(false)
+  const [result, setResult]     = useState(null)
+
+  // Live preview as slider moves (debounced).
+  useEffect(() => {
+    setLP(true)
+    const t = setTimeout(async () => {
+      try {
+        const params = new URLSearchParams()
+        if (minGrade) params.set('minGrade', minGrade)
+        if (minScore) params.set('minScore', String(minScore))
+        const r = await api.career.bulkQueuePreview(params)
+        setPreview(r)
+      } catch (e) { console.warn('preview err:', e); setPreview({ count: 0, rows: [] }) }
+      setLP(false)
+    }, 250)
+    return () => clearTimeout(t)
+  }, [minGrade, minScore])
+
+  async function queueAll() {
+    setQueuing(true)
+    try { const r = await api.career.bulkQueue({ minGrade, minScore }); setResult({ kind:'queued', n: r.queued }) }
+    catch (e) { setResult({ kind:'error', msg: e.message }) }
+    setQueuing(false)
+  }
+
+  async function runQueue() {
+    setRunning(true)
+    try { const r = await api.career.autoApplyRun(); setResult({ kind:'ran', summary: r }) }
+    catch (e) { setResult({ kind:'error', msg: e.message }) }
+    setRunning(false)
+  }
+
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap:18 }}>
+      <div style={{ background:'#fff', border:'1px solid #e2e8f0', borderRadius:14, padding:'24px 28px' }}>
+        <h2 style={{ fontSize:15, fontWeight:700, color:'#0f172a', margin:'0 0 18px' }}>Bulk Queue Evaluations</h2>
+
+        <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:24, marginBottom:24 }}>
+          <div>
+            <label style={{ display:'block', fontSize:11, fontWeight:700, color:'#64748b', textTransform:'uppercase', letterSpacing:'0.06em', marginBottom:8 }}>Minimum grade</label>
+            <div style={{ display:'flex', gap:6 }}>
+              {GRADE_ORDER.map(g => (
+                <button key={g} onClick={() => setMinGrade(g)}
+                  style={{ flex:1, padding:'8px 0', fontSize:13, fontWeight:700, border:`1px solid ${minGrade === g ? '#6366f1' : '#e2e8f0'}`, borderRadius:8, cursor:'pointer',
+                    background: minGrade === g ? '#eef2ff' : '#fff',
+                    color: minGrade === g ? '#4f46e5' : '#64748b' }}>{g}+</button>
+              ))}
+              <button onClick={() => setMinGrade('')}
+                style={{ flex:1, padding:'8px 0', fontSize:13, fontWeight:700, border:`1px solid ${!minGrade ? '#6366f1' : '#e2e8f0'}`, borderRadius:8, cursor:'pointer',
+                  background: !minGrade ? '#eef2ff' : '#fff',
+                  color: !minGrade ? '#4f46e5' : '#64748b' }}>Any</button>
+            </div>
+          </div>
+          <div>
+            <label style={{ display:'block', fontSize:11, fontWeight:700, color:'#64748b', textTransform:'uppercase', letterSpacing:'0.06em', marginBottom:8 }}>
+              Minimum score: <span style={{ color:'#0f172a' }}>{minScore}</span>
+            </label>
+            <input type="range" min={0} max={100} step={5} value={minScore} onChange={e => setMinScore(Number(e.target.value))}
+              style={{ width:'100%', accentColor:'#6366f1' }}/>
+          </div>
+        </div>
+
+        <div style={{ padding:'14px 16px', background: preview.count > 0 ? '#f0fdf4' : '#f8fafc', border:`1px solid ${preview.count > 0 ? '#bbf7d0' : '#e2e8f0'}`, borderRadius:10, marginBottom:16, display:'flex', alignItems:'center', justifyContent:'space-between' }}>
+          <div style={{ fontSize:13, fontWeight:600, color: preview.count > 0 ? '#15803d' : '#64748b' }}>
+            {loadingPreview ? '…' : `${preview.count} evaluation${preview.count === 1 ? '' : 's'} match${preview.count === 1 ? 'es' : ''}`}
+          </div>
+          <button onClick={queueAll} disabled={queuing || preview.count === 0}
+            style={{ padding:'8px 18px', fontSize:13, fontWeight:700, border:'none', borderRadius:8, cursor: queuing || preview.count === 0 ? 'default' : 'pointer',
+              background: preview.count > 0 ? 'linear-gradient(135deg,#6366f1,#7c3aed)' : '#e2e8f0',
+              color: preview.count > 0 ? '#fff' : '#94a3b8', opacity: queuing ? 0.6 : 1 }}>
+            {queuing ? 'Queueing…' : `Queue ${preview.count}`}
+          </button>
+        </div>
+
+        {/* Preview rows */}
+        {preview.rows.length > 0 && (
+          <div style={{ display:'flex', flexDirection:'column', gap:6, marginBottom:8 }}>
+            {preview.rows.slice(0, 5).map(r => (
+              <div key={r.id} style={{ padding:'8px 12px', background:'#f8fafc', borderRadius:7, fontSize:12, display:'flex', alignItems:'center', gap:10 }}>
+                <span style={{ display:'inline-block', minWidth:24, fontWeight:700, color:'#4f46e5' }}>{r.grade || '—'}</span>
+                <span style={{ flex:1, color:'#0f172a' }}>{r.job_title}</span>
+                <span style={{ color:'#94a3b8' }}>{r.company_name}</span>
+                <span style={{ color:'#64748b', fontVariantNumeric:'tabular-nums' }}>{r.score ?? '—'}</span>
+              </div>
+            ))}
+            {preview.rows.length > 5 && <div style={{ fontSize:11, color:'#94a3b8', textAlign:'center' }}>… +{preview.rows.length - 5} more</div>}
+          </div>
+        )}
+      </div>
+
+      <div style={{ background:'#fff', border:'1px solid #e2e8f0', borderRadius:14, padding:'24px 28px' }}>
+        <h2 style={{ fontSize:15, fontWeight:700, color:'#0f172a', margin:'0 0 8px' }}>Run Auto-Apply Worker</h2>
+        <p style={{ fontSize:12, color:'#94a3b8', margin:'0 0 18px' }}>Processes every evaluation marked Auto + queued. Supported portals: Greenhouse, Lever, Ashby.</p>
+        <button onClick={runQueue} disabled={running}
+          style={{ padding:'10px 22px', fontSize:13, fontWeight:700, background:'linear-gradient(135deg,#16a34a,#15803d)', color:'#fff', border:'none', borderRadius:10, cursor: running ? 'default':'pointer' }}>
+          {running ? 'Running…' : '⚡ Run Auto-Apply Queue'}
+        </button>
+      </div>
+
+      {result && (
+        <div style={{ padding:'14px 18px', background: result.kind === 'error' ? '#fef2f2' : '#f0fdf4', border:`1px solid ${result.kind === 'error' ? '#fca5a5' : '#bbf7d0'}`, borderRadius:10, fontSize:13, color: result.kind === 'error' ? '#dc2626' : '#15803d', fontWeight:600 }}>
+          {result.kind === 'queued' && `✓ Queued ${result.n} evaluation${result.n === 1 ? '' : 's'} for auto-apply.`}
+          {result.kind === 'ran'    && <span>✓ Run complete. {JSON.stringify(result.summary)}</span>}
+          {result.kind === 'error'  && `✗ ${result.msg}`}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ResumeFolderTab() {
+  const [data, setData] = useState({ resumeDir: '', resumes: [] })
+  const [err, setErr]   = useState(null)
+  useEffect(() => {
+    api.career.resumesLibrary().then(setData).catch(e => setErr(e.message))
+  }, [])
+  return (
+    <div style={{ background:'#fff', border:'1px solid #e2e8f0', borderRadius:14, padding:'24px 28px' }}>
+      <h2 style={{ fontSize:15, fontWeight:700, color:'#0f172a', margin:'0 0 6px' }}>Resume Folder</h2>
+      <p style={{ fontSize:12, color:'#94a3b8', margin:'0 0 6px' }}>
+        The auto-apply worker picks the resume from the sub-folder whose name matches the role's archetype.
+      </p>
+      <p style={{ fontSize:11, fontFamily:'ui-monospace, monospace', color:'#64748b', background:'#f8fafc', padding:'6px 10px', borderRadius:6, display:'inline-block', marginBottom:18 }}>
+        Scanning: {data.resumeDir || '(not set — update Profile)'}
+      </p>
+
+      {err && <div style={{ padding:'10px 14px', background:'#fef2f2', border:'1px solid #fca5a5', borderRadius:8, fontSize:12, color:'#dc2626' }}>✗ {err}</div>}
+
+      {data.resumes.length === 0 && !err && (
+        <div style={{ padding:'40px 0', textAlign:'center', color:'#94a3b8' }}>
+          <div style={{ fontSize:36, marginBottom:8 }}>📁</div>
+          <div style={{ fontSize:13, fontWeight:600 }}>No resume folders found</div>
+          <div style={{ fontSize:11, marginTop:4 }}>Drop role-specific PDFs into folders named AIML, SWE, DS, etc.</div>
+        </div>
+      )}
+
+      <div style={{ display:'grid', gridTemplateColumns:'repeat(auto-fill, minmax(220px, 1fr))', gap:12 }}>
+        {data.resumes.map(r => (
+          <div key={r.absPath} style={{ padding:'14px 16px', border:'1px solid #e2e8f0', borderRadius:10, background:'#fafbfc' }}>
+            <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:6 }}>
+              <span style={{ fontSize:11, fontWeight:700, color:'#4f46e5', textTransform:'uppercase', letterSpacing:'0.06em' }}>{r.archetype}</span>
+              <span style={{ fontSize:10, color:'#94a3b8' }}>{Math.round((r.sizeBytes || 0) / 1024)} KB</span>
+            </div>
+            <div style={{ fontSize:13, fontWeight:600, color:'#0f172a', marginBottom:2, wordBreak:'break-word' }}>{r.folder}</div>
+            <div style={{ fontSize:11, color:'#94a3b8', wordBreak:'break-word' }}>{r.filename}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function HistoryTab() {
+  const [rows, setRows] = useState([])
+  const [loading, setLoading] = useState(true)
+  useEffect(() => {
+    api.career.evaluations()
+      .then(d => {
+        const arr = Array.isArray(d) ? d : (d?.evaluations || [])
+        const applied = arr.filter(e => e.apply_status && e.apply_status !== 'not_started')
+        applied.sort((a, b) => (b.applied_at || '').localeCompare(a.applied_at || ''))
+        setRows(applied)
+      })
+      .catch(() => setRows([]))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return <div style={{ padding:'40px 0', textAlign:'center', color:'#94a3b8' }}>Loading…</div>
+
+  return (
+    <div style={{ background:'#fff', border:'1px solid #e2e8f0', borderRadius:14, padding:'24px 28px' }}>
+      <h2 style={{ fontSize:15, fontWeight:700, color:'#0f172a', margin:'0 0 18px' }}>Past Auto-Apply Runs · {rows.length}</h2>
+
+      {rows.length === 0 && (
+        <div style={{ padding:'40px 0', textAlign:'center', color:'#94a3b8' }}>
+          <div style={{ fontSize:36, marginBottom:8 }}>📜</div>
+          <div style={{ fontSize:13, fontWeight:600 }}>No applications submitted yet</div>
+          <div style={{ fontSize:11, marginTop:4 }}>Mark evaluations as auto + queued, then run the queue.</div>
+        </div>
+      )}
+
+      <div style={{ display:'flex', flexDirection:'column', gap:8 }}>
+        {rows.map(r => (
+          <div key={r.id} style={{ padding:'12px 16px', border:'1px solid #e2e8f0', borderRadius:10, display:'grid', gridTemplateColumns:'1fr 100px 100px 90px', gap:14, alignItems:'center', fontSize:13 }}>
+            <div>
+              <div style={{ fontWeight:700, color:'#0f172a' }}>{r.job_title}</div>
+              <div style={{ fontSize:11, color:'#94a3b8' }}>{r.company_name}</div>
+            </div>
+            <div style={{ fontWeight:700, color:'#4f46e5' }}>{r.grade || '—'}</div>
+            <div style={{ fontSize:11, fontWeight:600, padding:'3px 8px', borderRadius:5, background:'#eef2ff', color:'#4f46e5', textAlign:'center' }}>{r.apply_status}</div>
+            <div style={{ fontSize:11, color:'#94a3b8', textAlign:'right' }}>{r.applied_at ? new Date(r.applied_at).toLocaleDateString() : '—'}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/TemplatesPage.jsx
+++ b/frontend/src/components/TemplatesPage.jsx
@@ -1,0 +1,25 @@
+// Templates page — placeholder until the user pastes their preferred email
+// + DM templates. Once we have those, this becomes a small CRUD UI that
+// edits backend/services/ai.js prompt anchors per-user (stored in meta).
+
+export default function TemplatesPage() {
+  return (
+    <div style={{ flex:1, overflowY:'auto', background:'#f8fafc', padding:'40px' }}>
+      <div style={{ maxWidth:760, margin:'0 auto' }}>
+        <h1 style={{ fontSize:22, fontWeight:800, color:'#0f172a', margin:'0 0 4px' }}>Templates</h1>
+        <p style={{ fontSize:13, color:'#64748b', margin:'0 0 24px' }}>
+          Email + LinkedIn DM templates the AI uses as a style anchor when generating outreach.
+        </p>
+
+        <div style={{ background:'#fff', border:'1px solid #e2e8f0', borderRadius:14, padding:'40px', textAlign:'center' }}>
+          <div style={{ fontSize:36, marginBottom:12 }}>✏️</div>
+          <div style={{ fontSize:15, fontWeight:700, color:'#0f172a', marginBottom:6 }}>Templates editor coming soon</div>
+          <div style={{ fontSize:12, color:'#64748b', maxWidth:480, margin:'0 auto' }}>
+            Paste your preferred email + DM templates and the generator will mirror your tone, structure, and length.
+            Until then, the default prompt in <code style={{ background:'#f1f5f9', padding:'1px 6px', borderRadius:4 }}>backend/services/ai.js</code> is used.
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Reorganizes the sidebar from "9 flat top-level pages" into 3 collapsible sections grouped by user intent:

- **DISCOVER** (find roles → score them) — Companies, Job Scraper, Evaluate a Role
- **APPLY** (decide → submit → track) — **Auto Apply (NEW)**, Pipeline, Ranked Roles
- **OUTREACH** (cold reach-outs) — Messages, Templates (placeholder)

Same pages, just grouped + renamed to match how the product is actually used. Bookmarks for old URLs still work via 301 redirects.

## NEW: `/apply/auto-apply` page
4 tabs:
- **Setup** — reuses `<AutoApplySetup>` from `CareerOps.jsx` so the same profile editor + resume folder field + run button works.
- **Queue** — bulk-queue slider with live preview. Pick a minimum grade (A+/B+/C+/D+/F+/Any) and a minimum score (0-100). Live count updates as you drag, "Queue N" button flips matching evaluations to `apply_mode='auto', apply_status='queued'` in one shot. Then "Run Auto-Apply Queue" fires the Playwright worker.
- **Resume Folder** — lists every role-archetype PDF the backend resume-registry sees. Each card shows the archetype label (aiml / swe / ds / devops / fullstack / startup) so you can verify your folder names map correctly.
- **History** — past auto-apply runs (evaluations where `apply_status != 'not_started'`), sorted by `applied_at` desc.

## NEW: `/outreach/templates` placeholder
Stub page that will become the email + DM template editor once you paste your preferred templates.

## API additions (already deployed in `phase-4-pg`)
- `GET /api/career/bulk-queue/preview?minGrade=B&minScore=70` → `{ count, rows[] }`
- `POST /api/career/bulk-queue` body `{ minGrade, minScore }` → `{ queued }`

## Test plan
- [x] `npm run build --prefix frontend` → clean (80 modules, 673 KB bundle)
- [x] `node --test tests/api-client.test.mjs` → 5/5 pass
- [ ] After merge + Vercel rebuild: open `/apply/auto-apply`, drag the score slider, confirm count updates live; click Queue, confirm 2 existing evaluations get queued; click Run, confirm pm2 doesn't crash.
- [ ] Click old URLs (`/companies`, `/career-ops`, `/pipeline`, etc.) — confirm they 301 to the new paths.
- [ ] Sidebar shows 3 section headings and 8 nav items under them.

## Out of scope (Phase B follow-ups)
- Outreach CRM data flow bug (still awaiting your repro steps)
- Role Eligibility loading bug (still awaiting your DevTools console screenshot)
- Email/DM template content (Templates page is a placeholder until you paste templates)