### PR TITLE
fix(security): close cross-user mutation/leak vectors

### DIFF
--- a/backend/routes/automations.js
+++ b/backend/routes/automations.js
@@ -7,8 +7,6 @@ import { Router } from 'express';
 import { one, run } from '../db.js';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { scrapeAllSources } from '../services/scraper.js';
-import { evaluateJob } from '../services/jobEvaluator.js';
-import { fetchJobFromUrl } from '../services/jobEvaluator.js';
 
 const router = Router();
 
@@ -225,206 +223,18 @@ router.post('/ai-search', async (req, res) => {
   }
 });
 
-// ── POST /api/automations/auto-apply ─────────────────────────────────────────
-router.post('/auto-apply', async (req, res) => {
-  const { jobs, mode = 'review' } = req.body;
-
-  res.setHeader('Content-Type', 'text/event-stream');
-  res.setHeader('Cache-Control', 'no-cache');
-  res.setHeader('Connection', 'keep-alive');
-  res.setHeader('X-Accel-Buffering', 'no');
-  res.flushHeaders();
-
-  let closed = false;
-  req.on('close', () => { closed = true; });
-  function emit(event, data) {
-    if (!closed) res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
-  }
-
-  const id = 'auto-apply';
-  const resumeRow = await one(
-    "SELECT value FROM meta WHERE key = 'user_resume_text' AND user_id = $1",
-    [req.user.id]
-  );
-  const resumeText = resumeRow?.value;
-  if (!resumeText) {
-    emit('error', { error: 'No resume uploaded. Upload your resume in Career Ops first.' });
-    if (!closed) res.end();
-    return;
-  }
-
-  await logEntry(id, `Auto-apply started — ${jobs.length} jobs — mode: ${mode}`, req.user.id);
-  emit('log', { msg: `Starting ${mode === 'auto' ? 'Auto' : 'Review'} Mode for ${jobs.length} jobs…` });
-
-  const results = [];
-
-  for (const job of jobs) {
-    if (closed) break;
-    const applyUrl = job.applyUrl || '';
-
-    await logEntry(id, `Processing: ${job.title} at ${job.company}`, req.user.id);
-    emit('log', { msg: `Checking: ${job.title} at ${job.company}` });
-
-    let applyType = 'unknown';
-    if (applyUrl.includes('linkedin.com/jobs') || applyUrl.includes('linkedin.com/easy')) {
-      applyType = 'linkedin_easy_apply';
-    } else if (applyUrl.includes('greenhouse.io') || applyUrl.includes('boards.greenhouse')) {
-      applyType = 'greenhouse';
-    } else if (applyUrl.includes('lever.co')) {
-      applyType = 'lever';
-    } else if (applyUrl.includes('ashbyhq.com')) {
-      applyType = 'ashby';
-    }
-
-    emit('log', { msg: `  → Detected: ${applyType}` });
-    await logEntry(id, `Apply type: ${applyType} for ${applyUrl}`, req.user.id);
-
-    if (mode === 'review') {
-      emit('review', {
-        job: { ...job, applyType },
-        msg: `Review required: ${job.title} at ${job.company}`,
-      });
-      results.push({ job, status: 'pending_review', applyType });
-    } else {
-      try {
-        let status = 'skipped';
-        let note = '';
-
-        if (applyType === 'linkedin_easy_apply') {
-          const result = await applyLinkedIn(job, resumeText);
-          status = result.status;
-          note = result.note;
-        } else if (['greenhouse', 'lever', 'ashby'].includes(applyType)) {
-          const result = await applyATS(job, applyUrl, applyType, resumeText);
-          status = result.status;
-          note = result.note;
-        } else {
-          status = 'skipped';
-          note = 'Unknown apply type — manual application required';
-        }
-
-        await logEntry(id, `${job.company}: ${status} — ${note}`, req.user.id);
-        emit('log', { msg: `  → ${status}: ${note}` });
-        results.push({ job, status, note, applyType });
-
-        await run(`
-          INSERT INTO evaluations (job_url, job_title, company_name, grade, score, source, user_id)
-          VALUES ($1, $2, $3, 'N/A', 0, 'auto_apply', $4)
-        `, [applyUrl, job.title, job.company, req.user.id]);
-
-      } catch (err) {
-        await logEntry(id, `${job.company}: failed — ${err.message}`, req.user.id);
-        emit('log', { msg: `  → Failed: ${err.message}` });
-        results.push({ job, status: 'failed', note: err.message, applyType });
-      }
-
-      await new Promise(r => setTimeout(r, 2000));
-    }
-  }
-
-  emit('results', { results, total: results.length, mode });
-  emit('done', { msg: `${mode === 'review' ? 'Review mode complete' : 'Auto-apply complete'} — ${results.length} jobs processed` });
-  await logEntry(id, `Done — ${results.length} processed`, req.user.id);
-  if (!closed) res.end();
+// ── POST /api/automations/auto-apply — DEPRECATED ───────────────────────────
+// This legacy flow bypassed the consent gate, profile validation, sponsorship
+// check, and supported-ATS guards that the newer Career Ops auto-apply path
+// enforces. It also included a LinkedIn Easy Apply submitter that could submit
+// applications without those safeguards. Disabled to prevent silent submissions.
+//
+// Use POST /api/career/auto-apply/run (queue-driven) instead, which calls
+// processOneEvaluation() with the full safety pipeline.
+router.post('/auto-apply', (req, res) => {
+  res.status(410).json({
+    error: 'Endpoint removed. Use the Career Ops auto-apply queue (/api/career/auto-apply/run), which enforces consent and safety gates.',
+  });
 });
-
-// ── Playwright LinkedIn Easy Apply ───────────────────────────────────────────
-async function applyLinkedIn(job, resumeText) {
-  try {
-    const { chromium } = await import('playwright');
-    const cookie = process.env.LINKEDIN_SESSION_COOKIE;
-    if (!cookie) return { status: 'skipped', note: 'No LinkedIn session cookie configured' };
-
-    const browser = await chromium.launch({ headless: true });
-    const context = await browser.newContext();
-    await context.addCookies([{ name: 'li_at', value: cookie.trim(), domain: '.linkedin.com', path: '/' }]);
-    const page = await context.newPage();
-
-    try {
-      await page.goto(job.applyUrl, { timeout: 15000 });
-      await page.waitForTimeout(2000);
-
-      const easyApplyBtn = page.locator('button:has-text("Easy Apply"), .jobs-apply-button').first();
-      if (!(await easyApplyBtn.isVisible({ timeout: 5000 }).catch(() => false))) {
-        return { status: 'skipped', note: 'No Easy Apply button found — requires manual application' };
-      }
-
-      await easyApplyBtn.click();
-      await page.waitForTimeout(1500);
-
-      const modal = page.locator('.jobs-easy-apply-modal, [data-test-modal-id="easy-apply-modal"]');
-      if (!(await modal.isVisible({ timeout: 5000 }).catch(() => false))) {
-        return { status: 'skipped', note: 'Easy Apply modal did not open' };
-      }
-
-      const phoneInput = page.locator('input[id*="phone"], input[name*="phone"]').first();
-      if (await phoneInput.isVisible({ timeout: 2000 }).catch(() => false)) {
-        await phoneInput.fill(process.env.CANDIDATE_PHONE || '');
-      }
-
-      for (let step = 0; step < 5; step++) {
-        const nextBtn = page.locator('button:has-text("Next"), button:has-text("Continue"), button:has-text("Review")').first();
-        const submitBtn = page.locator('button:has-text("Submit application")').first();
-
-        if (await submitBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
-          await submitBtn.click();
-          await page.waitForTimeout(2000);
-          return { status: 'submitted', note: 'LinkedIn Easy Apply submitted successfully' };
-        }
-        if (await nextBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
-          await nextBtn.click();
-          await page.waitForTimeout(1000);
-        } else {
-          break;
-        }
-      }
-
-      return { status: 'partial', note: 'Reached review step — manual submission required' };
-    } finally {
-      await browser.close();
-    }
-  } catch (err) {
-    if (err.message.includes('Cannot find module')) {
-      return { status: 'skipped', note: 'Playwright not installed — run: npm install playwright && npx playwright install chromium' };
-    }
-    return { status: 'failed', note: err.message };
-  }
-}
-
-// ── ATS Apply (Greenhouse / Lever / Ashby) ────────────────────────────────────
-async function applyATS(job, applyUrl, type, resumeText) {
-  try {
-    const { chromium } = await import('playwright');
-    const browser = await chromium.launch({ headless: true });
-    const page = await browser.newPage();
-
-    try {
-      await page.goto(applyUrl, { timeout: 15000 });
-      await page.waitForTimeout(2000);
-
-      const nameInput = page.locator('input[name*="name"], input[id*="first_name"], input[placeholder*="First name"]').first();
-      if (await nameInput.isVisible({ timeout: 2000 }).catch(() => false)) {
-        await nameInput.fill('Sravya');
-      }
-      const lastInput = page.locator('input[name*="last_name"], input[id*="last_name"], input[placeholder*="Last name"]').first();
-      if (await lastInput.isVisible({ timeout: 2000 }).catch(() => false)) {
-        await lastInput.fill('Rachakonda');
-      }
-      const emailInput = page.locator('input[type="email"], input[name*="email"], input[id*="email"]').first();
-      if (await emailInput.isVisible({ timeout: 2000 }).catch(() => false)) {
-        await emailInput.fill(process.env.CANDIDATE_EMAIL || '');
-      }
-
-      return { status: 'filled', note: `Form filled on ${type} portal — manual submit required in Review mode` };
-    } finally {
-      await browser.close();
-    }
-  } catch (err) {
-    if (err.message.includes('Cannot find module')) {
-      return { status: 'skipped', note: 'Playwright not installed — run: npm install playwright && npx playwright install chromium' };
-    }
-    return { status: 'failed', note: err.message };
-  }
-}
 
 export default router;

--- a/backend/routes/careerOps.js
+++ b/backend/routes/careerOps.js
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'url';
 import { one, all, run, tx } from '../db.js';
 import { evaluateJob, fetchJobFromUrl } from '../services/jobEvaluator.js';
 import { tailorResume, generateResumePDF } from '../services/resumeGenerator.js';
-import { saveEvaluationReport, syncTracker, getTrackerRows } from '../services/reportManager.js';
+import { saveEvaluationReport, syncTracker } from '../services/reportManager.js';
 import { scanResumes, pickResumeForRole, detectPlatform } from '../services/resumeRegistry.js';
 import { processOneEvaluation, runQueueOnce } from '../services/autoApplier.js';
 import { runNightlyPipelineForUser } from '../services/nightlyPipeline.js';
@@ -1484,23 +1484,48 @@ router.post('/company/:id/score-fit', async (req, res) => {
   }
 });
 
-// ── GET /api/career/tracker — applications.md as JSON rows ────────────────────
-router.get('/tracker', (req, res) => {
+// ── GET /api/career/tracker — per-user evaluations as JSON rows ──────────────
+// Reads from the per-user `evaluations` table. Previously this read a global
+// applications.md file on disk, which leaked across users.
+router.get('/tracker', async (req, res) => {
   try {
-    syncTracker(); // drain any pending TSV first
-    const rows = getTrackerRows();
+    const evals = await all(`
+      SELECT id, company_name, job_title, score, grade, apply_status,
+             report_path, pdf_path, created_at
+      FROM evaluations
+      WHERE user_id = $1
+      ORDER BY created_at ASC
+    `, [req.user.id]);
+
+    const rows = evals.map((e, i) => {
+      const date = e.created_at ? new Date(e.created_at).toISOString().slice(0, 10) : '';
+      const score = e.score != null ? Number(e.score).toFixed(1) : '';
+      const status = e.apply_status || 'not_started';
+      const pdf = e.pdf_path ? path.basename(e.pdf_path) : '';
+      const report = e.report_path ? path.basename(e.report_path) : '';
+      return {
+        num: String(i + 1),
+        date,
+        company: e.company_name || '',
+        role: e.job_title || '',
+        score,
+        status,
+        pdf,
+        report,
+      };
+    });
+
     res.json({ rows, total: rows.length });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
 });
 
-// ── GET /api/career/tracker/raw — raw applications.md text ───────────────────
+// ── GET /api/career/tracker/raw — DEPRECATED ─────────────────────────────────
+// Previously served a global applications.md file. Removed to prevent cross-user
+// data leaks. Use GET /api/career/tracker for the per-user JSON feed.
 router.get('/tracker/raw', (req, res) => {
-  const p = path.join(__dirname, '..', 'data', 'applications.md');
-  if (!fs.existsSync(p)) return res.send('No evaluations yet.');
-  res.setHeader('Content-Type', 'text/plain');
-  res.send(fs.readFileSync(p, 'utf8'));
+  res.status(410).json({ error: 'Endpoint removed. Use /api/career/tracker (per-user JSON).' });
 });
 
 // ── GET /api/career/evaluations/:id/report.html — standalone styled HTML ─────
@@ -1704,58 +1729,17 @@ function renderEvaluationHtml(e, row) {
 </html>`;
 }
 
-// ── GET /api/career/reports — list saved reports ─────────────────────────────
-// Prefer the styled .html version per report; fall back to .md when HTML hasn't
-// been generated yet (e.g. reports saved before HTML generation was added).
+// ── GET /api/career/reports — DEPRECATED ─────────────────────────────────────
+// Previously listed every file in backend/data/reports/, which is shared across
+// users. Removed to prevent cross-user leakage. Use
+// /api/career/evaluations/:id/report.html for per-user, ownership-checked HTML
+// renders of saved evaluations.
 router.get('/reports', (req, res) => {
-  const dir = path.join(__dirname, '..', 'data', 'reports');
-  try {
-    const all = fs.readdirSync(dir);
-    const htmlNames = new Set(all.filter(f => f.endsWith('.html')).map(f => f.slice(0, -5)));
-    const mdStems   = all.filter(f => f.endsWith('.md')).map(f => f.slice(0, -3));
-    // Canonical list: one entry per stem, preferring the HTML variant.
-    const stems = Array.from(new Set([...htmlNames, ...mdStems])).sort().reverse();
-    const files = stems.map(stem => {
-      const isHtml = htmlNames.has(stem);
-      const filename = stem + (isHtml ? '.html' : '.md');
-      return {
-        filename,
-        format: isHtml ? 'html' : 'md',
-        url: `/api/career/reports/${filename}`,
-      };
-    });
-    res.json({ reports: files });
-  } catch (err) {
-    res.status(500).json({ error: err.message });
-  }
+  res.status(410).json({ error: 'Endpoint removed. Use /api/career/evaluations/:id/report.html.' });
 });
 
-// ── GET /api/career/reports/:filename — serve a saved report ──────────────────
-// - *.html → text/html (browser renders it as a page)
-// - *.md   → text/html too (render markdown as a basic HTML page so users no
-//            longer see raw markdown in the browser)
 router.get('/reports/:filename', (req, res) => {
-  const safe = path.basename(req.params.filename);
-  const dir  = path.join(__dirname, '..', 'data', 'reports');
-  const p    = path.join(dir, safe);
-  if (!fs.existsSync(p)) return res.status(404).send('<h1>Report not found</h1>');
-
-  if (safe.endsWith('.html')) {
-    res.setHeader('Content-Type', 'text/html; charset=utf-8');
-    return res.send(fs.readFileSync(p, 'utf8'));
-  }
-
-  if (safe.endsWith('.md')) {
-    // Auto-upgrade: if a sibling .html already exists, redirect to it.
-    const htmlSibling = path.join(dir, safe.replace(/\.md$/, '.html'));
-    if (fs.existsSync(htmlSibling)) return res.redirect(`/api/career/reports/${safe.replace(/\.md$/, '.html')}`);
-    // Otherwise render the markdown as a simple styled HTML page on the fly.
-    const md = fs.readFileSync(p, 'utf8');
-    res.setHeader('Content-Type', 'text/html; charset=utf-8');
-    return res.send(renderMarkdownAsHtml(md, safe));
-  }
-
-  res.status(400).send('<h1>Unsupported report format</h1>');
+  res.status(410).json({ error: 'Endpoint removed. Use /api/career/evaluations/:id/report.html.' });
 });
 
 // Tiny, dependency-free markdown → HTML renderer. Covers the subset used in

--- a/backend/routes/jobs.js
+++ b/backend/routes/jobs.js
@@ -896,26 +896,32 @@ router.get('/scraper-health', async (req, res) => {
 
 // ── Reclassify unclassified companies (exported for server startup) ────────────
 
-// TODO(auth): pass userId through from caller — this function is invoked from server
-// startup (no request context) as well as the HTTP handler below, so it can't read
-// req.user.id directly. Leaving queries un-scoped here; the HTTP wrapper is scoped.
-export async function runReclassifyUnclassified() {
+// User-scoped: caller MUST pass userId. Background callers (startup, cron) that
+// have no request context should pass an explicit user UUID or skip — global
+// reclassification across all users is no longer supported.
+export async function runReclassifyUnclassified(userId) {
+  if (!userId) {
+    console.log('[reclassify] skipped — no userId provided (background context)');
+    return { reclassified: 0, skipped: true };
+  }
+
   const rows = await all(`
     SELECT name, roles as jobTitle, '' as jobDescription
     FROM jobs
-    WHERE category = 'Unclassified' OR category IS NULL OR confidence < 0.40
+    WHERE user_id = $1
+      AND (category = 'Unclassified' OR category IS NULL OR confidence < 0.40)
     ORDER BY name
-  `);
+  `, [userId]);
 
   if (rows.length === 0) { console.log('[reclassify] nothing to reclassify'); return { reclassified: 0 }; }
-  console.log(`[reclassify] reclassifying ${rows.length} companies...`);
+  console.log(`[reclassify] reclassifying ${rows.length} companies for user ${userId}...`);
 
   const classifiedMap = await classifyCompanies(rows);
   const updateSql = `
     UPDATE jobs SET
       category = $1, subcategory = $2, confidence = $3,
       classified_at = $4, wikipedia_summary = COALESCE(wikipedia_summary, $5)
-    WHERE name = $6
+    WHERE user_id = $6 AND name = $7
   `;
 
   let reclassified = 0;
@@ -923,7 +929,7 @@ export async function runReclassifyUnclassified() {
     for (const row of rows) {
       const cls = classifiedMap.get(row.name.toLowerCase());
       if (!cls) continue;
-      await client.query(updateSql, [cls.category, cls.subcategory, cls.confidence, cls.classified_at, cls.wikipedia || '', row.name]);
+      await client.query(updateSql, [cls.category, cls.subcategory, cls.confidence, cls.classified_at, cls.wikipedia || '', userId, row.name]);
       if (cls.category !== 'Unclassified') reclassified++;
     }
   });
@@ -934,7 +940,7 @@ export async function runReclassifyUnclassified() {
 
 router.post('/reclassify-unclassified', async (req, res) => {
   try {
-    const result = await runReclassifyUnclassified();
+    const result = await runReclassifyUnclassified(req.user.id);
     const breakdown = await all('SELECT category, COUNT(*) as n FROM jobs WHERE user_id = $1 GROUP BY category ORDER BY n DESC', [req.user.id]);
     res.json({ ...result, breakdown });
   } catch (err) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -395,12 +395,16 @@ async function runDailyRefresh(userId, onProgress = null) {
     log('Skipping startup sheet refresh: no userId in cron context');
   }
 
-  // 3. Reclassify unclassified companies
-  try {
-    log('Reclassifying unclassified companies...');
-    await runReclassifyUnclassified();
-  } catch (err) {
-    log('Reclassify failed: ' + err.message);
+  // 3. Reclassify unclassified companies (per-user only)
+  if (userId) {
+    try {
+      log('Reclassifying unclassified companies...');
+      await runReclassifyUnclassified(userId);
+    } catch (err) {
+      log('Reclassify failed: ' + err.message);
+    }
+  } else {
+    log('Skipping reclassify: no userId in cron context');
   }
 
   // 4. Refresh credit status cache
@@ -488,18 +492,9 @@ async function startup() {
 
   app.listen(PORT, () => {
     console.log(`Backend on port ${PORT}`);
-    if (process.env.WIPE_DB_ON_START !== 'true') {
-      // Auto-reclassify unclassified companies in the background on startup
-      (async () => {
-        try {
-          const r = await one("SELECT COUNT(*)::int AS n FROM jobs WHERE category = 'Unclassified' OR category IS NULL OR confidence < 0.40");
-          if ((r?.n || 0) > 0) {
-            console.log(`[startup] ${r.n} unclassified/low-confidence companies — starting background reclassification...`);
-            runReclassifyUnclassified().catch(err => console.error('[startup reclassify]', err.message));
-          }
-        } catch (err) { console.error('[startup check]', err.message); }
-      })();
-    }
+    // Per-user reclassification now runs on demand via /api/jobs/reclassify-unclassified
+    // and as part of the daily refresh job (when a userId is supplied). The previous
+    // global startup pass mutated all users' jobs, so it has been removed.
   });
 }
 


### PR DESCRIPTION
## Summary

Three multi-user safety fixes flagged as Critical/High deploy blockers in the production-readiness audit. All three were vectors where one authenticated user could mutate, read, or apply on behalf of others.

- **`runReclassifyUnclassified()`** ([routes/jobs.js](backend/routes/jobs.js)) is now user-scoped on both SELECT and UPDATE. HTTP handler passes `req.user.id`. Background callers (daily refresh, server startup) skip when no userId is available, instead of doing a global pass over every user's `jobs` rows.
- **`/api/career/tracker`** now reads the per-user `evaluations` table instead of a global `data/applications.md` file. `/tracker/raw`, `/reports`, `/reports/:filename` → 410 (they served filesystem contents/listings shared across users; no frontend caller used them).
- **`/api/automations/auto-apply`** → 410. The legacy flow bypassed the Career Ops consent gate, profile validation, sponsorship check, and supported-ATS guards, and embedded a Playwright LinkedIn Easy Apply submitter. The submitter helpers (`applyLinkedIn`, `applyATS`) and unused `jobEvaluator` imports are removed so the submission code can't be silently re-wired. Use `POST /api/career/auto-apply/run` (queue-driven, full safety pipeline) instead.

Net diff: +83 / -288 lines.

## Compatibility

- Frontend `api.career.tracker()` is the only caller of any touched endpoint and keeps working — same `{ rows, total }` JSON shape, with rows containing `{ num, date, company, role, score, status, pdf, report }`. Verified against [CompanyDetail.jsx:1591-1617](../email%20tracker/frontend/src/components/CompanyDetail.jsx#L1591) which only reads `r.company`, `r.num`, `r.date`, `r.role`, `r.score`, `r.status`, `r.report`.
- `/career/reports*`, `/tracker/raw`, `/automations/auto-apply` have no in-tree frontend callers (only dead exports in `api.js`).

## Test plan

- [x] `node --check` on all four modified files
- [x] `npm test --prefix backend` — 12/12 pass
- [ ] Hit `/api/career/tracker` while signed in as user A and user B; verify each only sees own rows
- [ ] Hit `/api/career/tracker/raw`, `/api/career/reports`, `/api/career/reports/:f`, `/api/automations/auto-apply` and confirm 410 with the deprecation message
- [ ] Hit `POST /api/jobs/reclassify-unclassified` as user A; confirm only user A's `jobs` rows mutate (use a second user as a control)
- [ ] Restart backend and confirm no global startup reclassify pass runs (logs should show no `[startup reclassify]` line)
- [ ] Daily refresh cron with no userId should log `Skipping reclassify: no userId in cron context`