### PR TITLE
fix(security): stop leaking JWTs via download/report URLs

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -6,10 +6,15 @@
 // owns all data access and business logic. Supabase is only used for auth:
 //   - App.jsx / Login.jsx drive the login flow
 //   - this module reads the current session JWT and attaches it to every
-//     outbound request (Authorization: Bearer <jwt>). For URL-returning
-//     helpers (EventSource, window.open, <a href>) — which can't set headers
-//     — the token is appended via ?access_token=<jwt>. The backend middleware
-//     accepts either source.
+//     outbound request (Authorization: Bearer <jwt>).
+//
+// Downloads / report views fetch the resource with the Bearer header, then
+// open it as a blob: URL — JWTs no longer leak into address bars, browser
+// history, server access logs, or Referer headers.
+//
+// EventSource (SSE) is the one carve-out: it can't send headers, so the SSE
+// helpers append ?access_token=<jwt> via withAuthQuery. The backend middleware
+// accepts either source.
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { supabase } from './supabaseClient.js'
@@ -22,9 +27,10 @@ export const apiUrl = (path = '') => `${API}${path.startsWith('/') ? path : `/${
 const isFormData = (body) => typeof FormData !== 'undefined' && body instanceof FormData
 
 // ── Auth token plumbing ─────────────────────────────────────────────────────
-// URL-returning helpers need a sync read of the current JWT (they're called
-// inside JSX: <a href={reportHtmlUrl(id)}>, new EventSource(...), window.open).
-// Keep a cached copy updated by Supabase's auth state.
+// SSE helpers (EventSource-based streams) need a sync read of the current JWT,
+// since EventSource cannot send Authorization headers. Keep a cached copy
+// updated by Supabase's auth state. Non-streaming requests use authHeaders()
+// which always grabs the freshest session token.
 let cachedToken = null
 try {
   supabase.auth.getSession().then(({ data: { session } }) => {
@@ -85,6 +91,39 @@ export async function rawApiFetch(url, options = {}) {
   const auth = await authHeaders()
   const headers = options.headers ? { ...auth, ...options.headers } : auth
   return fetch(apiUrl(url), { ...options, headers })
+}
+
+async function fetchAuthenticatedBlob(path) {
+  const res = await rawApiFetch(path)
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error(err.error || 'Request failed')
+  }
+  return res.blob()
+}
+
+// Open a backend resource in a new tab using a blob URL — keeps the JWT in
+// the Authorization header rather than leaking it via ?access_token=.
+export async function openAuthenticatedTab(path) {
+  const blob = await fetchAuthenticatedBlob(path)
+  const url = URL.createObjectURL(blob)
+  const w = window.open(url, '_blank', 'noopener,noreferrer')
+  // Revoke later so the new tab has time to load before the URL is freed.
+  setTimeout(() => URL.revokeObjectURL(url), 60_000)
+  return w
+}
+
+// Trigger a file download via blob URL with the suggested filename.
+export async function downloadAuthenticatedFile(path, filename) {
+  const blob = await fetchAuthenticatedBlob(path)
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  if (filename) a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  setTimeout(() => URL.revokeObjectURL(url), 5_000)
 }
 
 const qs = (params) => {
@@ -286,11 +325,13 @@ export const api = {
       return apiCall(`/career/${companyId}/documents`, { method: 'POST', body: fd })
     },
     deleteDocument:   (companyId, docId) => apiCall(`/career/${companyId}/documents/${docId}`, { method: 'DELETE' }),
-    downloadDocument: (companyId, docId) => withAuthQuery(apiUrl(`/career/${companyId}/documents/${docId}/download`)),
+    downloadDocument: (companyId, docId, filename) =>
+      downloadAuthenticatedFile(`/career/${companyId}/documents/${docId}/download`, filename),
 
-    // ── Report / download URLs — backend renders the HTML/PDF directly ───────
-    reportHtmlUrl:  (id) => withAuthQuery(apiUrl(`/career/evaluations/${id}/report.html`)),
-    downloadUrl:    (id) => withAuthQuery(apiUrl(`/career/download/${id}`)),
+    // ── Report / download — fetched with Bearer auth and opened as a blob URL,
+    //    so the JWT never appears in URLs, history, or referrers.
+    openReportTab:        (id) => openAuthenticatedTab(`/career/evaluations/${id}/report.html`),
+    downloadEvaluationPdf: (id, filename) => downloadAuthenticatedFile(`/career/download/${id}`, filename),
     tailoredResume: (id) => apiCall(`/career/tailored-resume/${id}`, { method: 'POST' }),
   },
 

--- a/frontend/src/components/ApplicationPipeline.jsx
+++ b/frontend/src/components/ApplicationPipeline.jsx
@@ -83,8 +83,9 @@ export default function ApplicationPipeline() {
     } catch (err) { alert('Move failed: ' + err.message) }
   }
 
-  function openReport(id) {
-    window.open(api.career.reportHtmlUrl(id), '_blank', 'noopener,noreferrer')
+  async function openReport(id) {
+    try { await api.career.openReportTab(id) }
+    catch (err) { alert('Could not open report: ' + err.message) }
   }
 
   return (

--- a/frontend/src/components/CareerOps.jsx
+++ b/frontend/src/components/CareerOps.jsx
@@ -120,7 +120,7 @@ function ResumeUpload({ resumeInfo, onUploaded }) {
 }
 
 // ── Evaluation report — renders santifer's A-G schema ────────────────────────
-function EvaluationReport({ evaluation: e, onGeneratePDF, pdfLoading, pdfUrl, applyMode, applyStatus, onApplyModeChange, onApply, applying, onQueue, queuing }) {
+function EvaluationReport({ evaluation: e, onGeneratePDF, pdfLoading, pdfReady, onDownloadPdf, applyMode, applyStatus, onApplyModeChange, onApply, applying, onQueue, queuing }) {
   const gc = gradeColor(e.grade)
   const gb = gradeBg(e.grade)
 
@@ -193,10 +193,10 @@ function EvaluationReport({ evaluation: e, onGeneratePDF, pdfLoading, pdfUrl, ap
               ✓ In auto-apply queue
             </div>
           )}
-          {pdfUrl ? (
-            <a href={pdfUrl} download style={{ padding:'8px 14px', fontSize:11, fontWeight:700, background:'#16a34a', color:'#fff', borderRadius:8, textAlign:'center', textDecoration:'none' }}>
+          {pdfReady ? (
+            <button onClick={onDownloadPdf} style={{ padding:'8px 14px', fontSize:11, fontWeight:700, background:'#16a34a', color:'#fff', border:'none', borderRadius:8, textAlign:'center', cursor:'pointer' }}>
               ⬇ Download Tailored CV
-            </a>
+            </button>
           ) : (
             <button onClick={onGeneratePDF} disabled={pdfLoading}
               style={{ padding:'8px 14px', fontSize:11, fontWeight:700, background:'#fff', color:'#4f46e5', border:'1px solid #c7d2fe', borderRadius:8, cursor:'pointer', display:'flex', alignItems:'center', justifyContent:'center', gap:6 }}>
@@ -942,10 +942,14 @@ function EvalCard({ ev, onClick, onDelete, onQueue }) {
         style={{ padding:'6px 12px', fontSize:11, fontWeight:700, background: queued ? '#dcfce7' : '#fef3c7', color: queued ? '#15803d' : '#b45309', border:`1px solid ${queued ? '#86efac' : '#fcd34d'}`, borderRadius:7, cursor: queued || queuing ? 'default' : 'pointer', flexShrink:0, display:'flex', alignItems:'center', gap:4 }}>
         {queuing ? <Spin size={11} /> : queued ? '✓ Queued' : '+ Auto-Apply'}
       </button>
-      <a href={api.career.reportHtmlUrl(ev.id)} target="_blank" rel="noreferrer" onClick={e => e.stopPropagation()}
-        style={{ padding:'6px 12px', fontSize:11, fontWeight:700, background:'#eef2ff', color:'#4f46e5', border:'1px solid #c7d2fe', borderRadius:7, textDecoration:'none', flexShrink:0 }}>
+      <button onClick={async e => {
+          e.stopPropagation()
+          try { await api.career.openReportTab(ev.id) }
+          catch (err) { alert('Could not open report: ' + err.message) }
+        }}
+        style={{ padding:'6px 12px', fontSize:11, fontWeight:700, background:'#eef2ff', color:'#4f46e5', border:'1px solid #c7d2fe', borderRadius:7, cursor:'pointer', flexShrink:0 }}>
         HTML ↗
-      </a>
+      </button>
       {ev.pdf_path && <span title="PDF generated" style={{ fontSize:18 }}>📄</span>}
       <button onClick={e => { e.stopPropagation(); onDelete(ev.id) }}
         style={{ padding:'5px 10px', fontSize:11, background:'none', border:'1px solid #fecaca', color:'#dc2626', borderRadius:7, cursor:'pointer', flexShrink:0 }}>
@@ -1238,7 +1242,7 @@ export default function CareerOps() {
   const [history, setHistory]       = useState([])
   const [histLoading, setHistLoading] = useState(false)
   const [pdfLoading, setPdfLoading] = useState(false)
-  const [pdfUrl, setPdfUrl]         = useState(null)
+  const [pdfReady, setPdfReady]     = useState(false)
   const [applyMode, setApplyMode]   = useState('manual') // per-evaluation: 'manual' | 'auto'
   const [applyStatus, setApplyStatus] = useState('not_started')
   const [applying, setApplying]     = useState(false)
@@ -1281,7 +1285,7 @@ export default function CareerOps() {
     if (resumeMode === 'paste' && resumePasted.trim().length < 50) { setEvalError('Pasted resume looks too short — paste the full text'); return }
     if (resumeMode === 'upload' && !resumeUploadedText) { setEvalError('Upload a PDF first'); return }
     if (resumeMode === 'saved' && !resumeInfo?.hasResume) { setEvalError('No saved resume — pick Upload or Paste, or upload a default in Auto-Apply Setup'); return }
-    setEvaluating(true); setEvalError(null); setEvaluation(null); setPdfUrl(null)
+    setEvaluating(true); setEvalError(null); setEvaluation(null); setPdfReady(false)
     setApplyMode('manual'); setApplyStatus('not_started')
     try {
       const isUrl = input.trim().startsWith('http')
@@ -1351,9 +1355,17 @@ export default function CareerOps() {
   async function handleGeneratePDF() {
     if (!evalId) return
     setPdfLoading(true)
-    try { const r = await api.career.tailoredResume(evalId); if (r.ok) setPdfUrl(r.downloadUrl) }
+    try { const r = await api.career.tailoredResume(evalId); if (r.ok) setPdfReady(true) }
     catch (err) { alert('PDF generation failed: ' + err.message) }
     finally { setPdfLoading(false) }
+  }
+
+  async function handleDownloadPdf() {
+    if (!evalId) return
+    const safe = (s) => String(s || '').replace(/[/\\?%*:|"<>]/g, '_').slice(0, 80)
+    const filename = `${safe(evaluation?.companyName) || 'company'}-${safe(evaluation?.jobTitle) || 'role'}.pdf`
+    try { await api.career.downloadEvaluationPdf(evalId, filename) }
+    catch (err) { alert('Download failed: ' + err.message) }
   }
 
   async function handleDeleteEval(id) {
@@ -1364,7 +1376,7 @@ export default function CareerOps() {
   async function loadEvalFromHistory(ev) {
     const r = await api.career.evaluation(ev.id)
     setEvaluation(r.evaluation); setEvalId(r.id)
-    setPdfUrl(r.pdf_path ? api.career.downloadUrl(r.id) : null)
+    setPdfReady(!!r.pdf_path)
     setApplyMode(r.apply_mode || 'manual')
     setApplyStatus(r.apply_status || 'not_started')
     setTab('evaluate')
@@ -1542,7 +1554,8 @@ export default function CareerOps() {
                 evaluation={evaluation}
                 onGeneratePDF={handleGeneratePDF}
                 pdfLoading={pdfLoading}
-                pdfUrl={pdfUrl}
+                pdfReady={pdfReady}
+                onDownloadPdf={handleDownloadPdf}
                 applyMode={applyMode}
                 applyStatus={applyStatus}
                 onApplyModeChange={handleApplyModeChange}

--- a/frontend/src/components/CompanyDetail.jsx
+++ b/frontend/src/components/CompanyDetail.jsx
@@ -1305,7 +1305,9 @@ function CareerOpsTab({ company, autoAnalyze, onAnalyzeDone }) {
     try {
       const data = await api.career.tailoredResume(evalId)
       if (data.error) { setPdfError(data.error); return }
-      window.open(api.career.downloadUrl(evalId), '_blank')
+      const safe = (s) => String(s || '').replace(/[/\\?%*:|"<>]/g, '_').slice(0, 80)
+      const filename = `${safe(company?.name) || 'company'}-tailored.pdf`
+      await api.career.downloadEvaluationPdf(evalId, filename)
     } catch (err) {
       setPdfError(err.message)
     }
@@ -1658,10 +1660,13 @@ function CareerOpsTab({ company, autoAnalyze, onAnalyzeDone }) {
                         {r.score != null && ` · ${Number(r.score).toFixed(1)}/5`}
                       </div>
                     </div>
-                    <a href={api.career.reportHtmlUrl(r.id)} target="_blank" rel="noreferrer"
-                      style={{ padding:'6px 14px', background:'#6366f1', color:'#fff', borderRadius:7, fontSize:11, fontWeight:700, textDecoration:'none', flexShrink:0 }}>
+                    <button onClick={async () => {
+                        try { await api.career.openReportTab(r.id) }
+                        catch (err) { alert('Could not open report: ' + err.message) }
+                      }}
+                      style={{ padding:'6px 14px', background:'#6366f1', color:'#fff', border:'none', borderRadius:7, fontSize:11, fontWeight:700, cursor:'pointer', flexShrink:0 }}>
                       View report →
-                    </a>
+                    </button>
                   </div>
                 ))}
               </div>

--- a/frontend/src/components/JobDashboard.jsx
+++ b/frontend/src/components/JobDashboard.jsx
@@ -189,8 +189,12 @@ export default function JobDashboard() {
               <div style={{ fontSize:13, color:'#94a3b8' }}>No evaluations yet.</div>
             ) : (
               recentEvals.slice(0, 8).map((e, i) => (
-                <a key={i} href={api.career.reportHtmlUrl(e.id)} target="_blank" rel="noreferrer"
-                  style={{ display:'flex', alignItems:'center', gap:10, padding:'8px 0', borderBottom: i < recentEvals.length - 1 ? '1px solid #f1f5f9' : 'none', textDecoration:'none' }}>
+                <button key={i} type="button"
+                  onClick={async () => {
+                    try { await api.career.openReportTab(e.id) }
+                    catch (err) { alert('Could not open report: ' + err.message) }
+                  }}
+                  style={{ display:'flex', alignItems:'center', gap:10, padding:'8px 0', textAlign:'left', background:'none', border:'none', borderRadius:0, borderBottom: i < recentEvals.length - 1 ? '1px solid #f1f5f9' : 'none', cursor:'pointer', width:'100%' }}>
                   <div style={{ width:26, height:26, borderRadius:'50%', border:`2px solid ${GRADE_COLOR[e.grade] || '#94a3b8'}`, display:'flex', alignItems:'center', justifyContent:'center', flexShrink:0 }}>
                     <span style={{ fontSize:11, fontWeight:900, color: GRADE_COLOR[e.grade] || '#94a3b8' }}>{e.grade || '—'}</span>
                   </div>
@@ -198,7 +202,7 @@ export default function JobDashboard() {
                     <div style={{ fontSize:12, fontWeight:700, color:'#0f172a', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{e.job_title}</div>
                     <div style={{ fontSize:11, color:'#94a3b8' }}>{e.company_name} · {timeAgo(e.created_at)}</div>
                   </div>
-                </a>
+                </button>
               ))
             )}
           </div>

--- a/tests/api-client.test.mjs
+++ b/tests/api-client.test.mjs
@@ -58,10 +58,16 @@ test('raw URL helpers respect the shared API base', () => {
   return api.unified.allContacts(params)
 })
 
-test('career document/report URLs use the shared API base', () => {
-  assert.equal(api.career.downloadUrl(5), '/api/career/download/5')
-  assert.equal(api.career.reportHtmlUrl(5), '/api/career/evaluations/5/report.html')
+test('SSE URL helpers are URL builders; download/report helpers are async actions', () => {
+  // SSE streams keep using ?access_token=<jwt> because EventSource cannot send
+  // headers. With no cached token the helper just returns the bare URL.
   assert.equal(api.career.scoreFitUrl(9), '/api/career/company/9/score-fit')
+
+  // Downloads and report views fetch with Bearer auth and open as blob URLs —
+  // they're action helpers, not URL builders, so the JWT never reaches the URL.
+  assert.equal(typeof api.career.openReportTab, 'function')
+  assert.equal(typeof api.career.downloadEvaluationPdf, 'function')
+  assert.equal(typeof api.career.downloadDocument, 'function')
 })
 
 test('raw API fetch keeps direct calls on the authenticated API helper path', async () => {


### PR DESCRIPTION
## Summary

Audit fix #4 (High severity): JWTs were appended as `?access_token=<jwt>` to download and report URLs, which leaks tokens through the address bar, browser history, server access logs, and Referer headers when the resource embeds external links.

This PR switches downloads/reports to authenticated `fetch()` with the Bearer header, then opens/saves the response as a blob URL — no token in any URL.

## Scope

- [api.js](frontend/src/api.js): added `fetchAuthenticatedBlob`, `openAuthenticatedTab`, `downloadAuthenticatedFile`. The 3 audit-flagged URL builders (`reportHtmlUrl`, `downloadUrl`, `downloadDocument`) become action helpers (`openReportTab`, `downloadEvaluationPdf`, `downloadDocument`).
- 6 call sites in 4 components updated:
  - `ApplicationPipeline.jsx`: report open
  - `CareerOps.jsx` (×3): tailored-CV download flow (`pdfUrl` state → `pdfReady` boolean), HTML report button
  - `CompanyDetail.jsx` (×2): PDF generation, report view
  - `JobDashboard.jsx`: recent-evaluation tiles
- `tests/api-client.test.mjs`: assertion updated to match the new shape (URL builders for SSE only, action helpers for downloads/reports).

**SSE streams are intentionally exempt** — `findPeopleStream` and `scoreFitUrl` keep `withAuthQuery` because EventSource cannot send Authorization headers. The audit's High-severity flag was specifically about reports/downloads.

Net diff: +105 / -35 lines.

## Tradeoff

Blob URLs (`blob:https://...`) are not bookmarkable, can't be shared, and don't survive tab reload. Acceptable for one-shot view/download UX. Right-click → "open in new tab" no longer works on report buttons (they're `<button>`s now, not `<a>`s) — minor regression.

## Test plan

- [x] `npm test` (frontend) — 7/7 pass
- [x] `npm run lint --prefix frontend` — clean
- [x] `npm run build --prefix frontend` — clean (pre-existing >500 kB chunk warning unchanged)
- [ ] Manual: sign in, click "View report" on an evaluation tile (Dashboard, Career Ops history, Company Detail, Pipeline). Verify a new tab opens with the styled HTML report and the URL bar shows `blob:https://...` rather than the API URL with `?access_token=`.
- [ ] Manual: sign in, generate a tailored CV in Career Ops; click "Download Tailored CV". Confirm a PDF downloads with a filename like `<company>-<role>.pdf` and no token shows up in browser network history.
- [ ] Manual: load an evaluation from history that already has `pdf_path`. Confirm the green "Download Tailored CV" button appears and downloads.
- [ ] Manual: open browser dev tools → Network tab → filter by "report.html". Confirm the request carries `Authorization: Bearer ...` and no `access_token` query param.
- [ ] Manual: confirm SSE streams (find-people, score-fit) still work — those intentionally keep `?access_token=`.