### PR TITLE
fix(security): drop founder UUID default on user_id columns

### DIFF
--- a/supabase/migrations/007_drop_user_id_default.sql
+++ b/supabase/migrations/007_drop_user_id_default.sql
@@ -1,0 +1,51 @@
+-- ============================================================================
+-- Migration 007 — drop the founder UUID DEFAULT on user_id columns
+-- ============================================================================
+--
+-- Final pass of the per-user isolation rollout (see 003 / 004).
+--
+-- Migration 003 added user_id with DEFAULT '70df2946-…' (founding user) so
+-- legacy inserts that didn't pass user_id still attributed to the founder.
+-- Migration 004 set user_id NOT NULL but left the DEFAULT in place as a
+-- safety net while background paths still lacked an explicit userId.
+--
+-- All known INSERT statements in the codebase now pass user_id explicitly
+-- (verified: 53/53 INSERTs across routes + services include user_id in
+-- their column list). Background paths (daily refresh, startup reclassify,
+-- nightly cron) either pass an explicit userId or skip per-user writes.
+-- This migration removes the safety net so any future INSERT that forgets
+-- user_id fails loudly with a NOT NULL violation, instead of silently
+-- attributing the row to the founder.
+--
+-- Idempotent: DROP DEFAULT is a no-op if no DEFAULT exists.
+--
+-- Roll back (if a forgotten INSERT path surfaces):
+--   ALTER TABLE public.<t> ALTER COLUMN user_id
+--     SET DEFAULT '70df2946-a46e-4b63-832c-2822cda4cf4b';
+-- ============================================================================
+
+BEGIN;
+
+DO $$
+DECLARE
+  t TEXT;
+BEGIN
+  FOR t IN SELECT unnest(ARRAY[
+    'jobs','companies','contacts','outreach','job_contacts','prospects',
+    'evaluations','activity_log','roles','company_applications','documents'
+  ]) LOOP
+    EXECUTE format('ALTER TABLE public.%I ALTER COLUMN user_id DROP DEFAULT', t);
+  END LOOP;
+END $$;
+
+COMMIT;
+
+-- ============================================================================
+-- Post-migration sanity:
+--   SELECT table_name, column_name, column_default, is_nullable
+--     FROM information_schema.columns
+--    WHERE column_name = 'user_id' AND table_schema = 'public'
+--    ORDER BY table_name;
+--   -- expect: column_default IS NULL, is_nullable = 'NO' on every row
+--   -- for the 11 tables above.
+-- ============================================================================


### PR DESCRIPTION
## Summary

Audit fix #5: production DB still had a `DEFAULT '70df2946-…'` (founding user) on the `user_id` column of every per-user table. Migration 003 added it as a rollout safety net; migration 004 promised to drop it once code paths passed user_id explicitly. This is that follow-up.

## Why now

Pre-audit, code audit confirms every INSERT in `routes/` and `services/` (53/53) now includes `user_id` in its column list. Background paths (`runDailyRefresh`, startup reclassify, nightly cron, `runNightlyPipelineForUser`, `importStartupSheet`) either pass an explicit `userId` or skip the per-user write. So:

- The DEFAULT no longer protects a real code path.
- It silently hides bugs: any future INSERT that forgets user_id silently writes the row to the founder's account, contaminating their data and granting them visibility into other users' content.

This migration drops the DEFAULT on the 11 tables that had it. After it runs, a forgotten `user_id` fails with `NOT NULL` instead.

## Scope

- New migration: `007_drop_user_id_default.sql`
- 11 tables: `jobs`, `companies`, `contacts`, `outreach`, `job_contacts`, `prospects`, `evaluations`, `activity_log`, `roles`, `company_applications`, `documents`
- `meta` and `user_profile` had `user_id` added in 003 without a DEFAULT, so they're already correct — no change needed.

Idempotent; rollback documented in the migration header.

## Relationship to PR #9

Independent. PR #9 fixes cross-user reads/updates (different vector). #5's only precondition is "every INSERT path passes user_id explicitly", which is true today regardless of whether #9 has merged.

## Test plan

- [ ] Apply 007 against a Supabase staging clone of prod.
- [ ] Run the post-migration sanity query in the migration footer; confirm `column_default IS NULL` and `is_nullable = 'NO'` for every row of the 11 tables.
- [ ] Smoke-test: sign in, scrape companies, evaluate a role, generate a tailored CV, save a contact, send an outreach. All flows should succeed.
- [ ] Run `INSERT INTO jobs (name, source) VALUES ('test', 'manual')` in psql with no user_id; confirm it fails with `null value in column "user_id"`.
- [ ] If a regression appears in production, rollback by re-adding the DEFAULT (migration footer has the SQL).