### PR TITLE
fix(privacy): enforce demographic_consent gate on profile writes

### DIFF
--- a/backend/routes/careerOps.js
+++ b/backend/routes/careerOps.js
@@ -216,6 +216,14 @@ router.get('/profile', async (req, res) => {
   } catch (err) { res.status(500).json({ error: err.message }); }
 });
 
+// Demographic fields are only persisted when the user has set demographic_consent=1.
+// Withdrawing consent (setting it back to 0) also clears any previously-stored values.
+const DEMOGRAPHIC_FIELDS = ['gender', 'race', 'veteran_status', 'disability_status'];
+
+function isTruthyConsent(v) {
+  return v === 1 || v === '1' || v === true || v === 'true';
+}
+
 router.put('/profile', async (req, res) => {
   try {
     const ALLOWED = [
@@ -227,7 +235,33 @@ router.put('/profile', async (req, res) => {
       'gender','race','veteran_status','disability_status','demographic_consent','auto_apply_consent',
       'resume_dir',
     ];
-    const data = req.body || {};
+    const data = { ...(req.body || {}) };
+
+    // ── Demographic consent gate ────────────────────────────────────────────
+    // 1. If the request writes any demographic field, consent must already be
+    //    granted (existing row) OR be granted in this same request.
+    // 2. If the request *withdraws* consent (consent → 0), force-null all
+    //    demographic fields so withdrawal is a real erasure.
+    const writesDemographics = DEMOGRAPHIC_FIELDS.some(k => Object.prototype.hasOwnProperty.call(data, k));
+    const consentInPatch     = Object.prototype.hasOwnProperty.call(data, 'demographic_consent');
+    const consentNowTrue     = consentInPatch && isTruthyConsent(data.demographic_consent);
+    const consentBeingWithdrawn = consentInPatch && !isTruthyConsent(data.demographic_consent);
+
+    if (writesDemographics && !consentNowTrue) {
+      const existing = await one('SELECT demographic_consent FROM user_profile WHERE user_id = $1', [req.user.id]);
+      if (!isTruthyConsent(existing?.demographic_consent)) {
+        return res.status(403).json({
+          error: 'Demographic fields require demographic_consent=1. Set consent in the same request or first.',
+        });
+      }
+    }
+
+    if (consentBeingWithdrawn) {
+      // Force every demographic field to NULL on consent withdrawal, regardless
+      // of what the client sent.
+      for (const k of DEMOGRAPHIC_FIELDS) data[k] = null;
+    }
+
     const cols = [], placeholders = [], updates = [], args = [];
     let i = 1;
     // user_id is always first param for both INSERT + UPDATE WHERE


### PR DESCRIPTION
## Summary

Audit fix #8 sub-task 3 — closes the consent enforcement gap.

The audit said: *\"Consent exists, but demographic consent does not appear to prevent saving selected demographic values; it is just another saved field.\"* That's accurate — \`PUT /api/career/profile\` happily accepted \`gender\` / \`race\` / \`veteran_status\` / \`disability_status\` regardless of what \`demographic_consent\` was set to. The frontend collected consent in the UI, but no server-side check.

## Behavior change

- **Writing demographics requires consent.** If the PUT body contains any of the 4 demographic fields, \`demographic_consent\` must be truthy in either (a) the existing \`user_profile\` row, or (b) the same request. Otherwise → \`403\` with a clear error.
- **Consent withdrawal is real erasure.** Setting \`demographic_consent: 0\` in the PUT body force-nulls the 4 demographic fields in the same upsert, ignoring whatever the client sent for them. So \"I revoke my consent\" actually clears the data.
- **Other consent flags untouched** (\`auto_apply_consent\` etc.).

## Files

- \`backend/routes/careerOps.js\` — added \`DEMOGRAPHIC_FIELDS\` const + \`isTruthyConsent\` helper + the gate. ~35 line addition.

## Tests

- Backend tests: 12/12 still pass (\`npm test --prefix backend\`).
- No new test added — backend route tests would need an Express harness that doesn't exist yet. Will be covered by #6 Playwright e2e once that lands.

## Out of scope (for #8)

- (1) GDPR-style \`/api/profile/export\` and \`/api/profile/delete\` endpoints — deferred until there's a second user.
- (2) Field-level encryption / sensitive-table split — deferred; consent gate is enough for v1.