### PR TITLE
test(e2e): Playwright harness + landing-page smoke test (PR-A of #6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ backend/resumes/
 coverage/
 .nyc_output/
 __pycache__/
+test-results/
+playwright-report/
+.playwright/
 
 # OS specific
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -102,16 +102,22 @@ VITE_API_URL=https://outreach-jt.duckdns.org  # production only — leave unset 
 ## 🧪 Tests
 
 ```bash
-npm test  # runs node --test against tests/ (currently: tests/api-client.test.mjs)
+npm test                  # node --test against tests/*.test.mjs
+npm run typecheck         # node --check sweep + ESLint
+npm run verify-baseline   # probe prod for the audit-fix endpoints
+npm run verify-migrations # schema invariants (DATABASE_URL optional)
 ```
 
-Frontend build check:
+End-to-end (Playwright):
+```bash
+npm run test:e2e:install  # one-time: download chromium (~150 MB)
+npm run test:e2e          # runs against PLAYWRIGHT_BASE_URL (default: prod Vercel)
+PLAYWRIGHT_BASE_URL=http://localhost:5173 npm run test:e2e   # local dev
+```
+
+Frontend build / lint:
 ```bash
 npm run build --prefix frontend
-```
-
-Lint:
-```bash
 npm run lint --prefix frontend
 ```
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "lint": "npm run lint --prefix frontend",
     "preview": "npm run preview --prefix frontend",
     "test": "node --test tests/*.test.mjs",
+    "test:e2e": "playwright test",
+    "test:e2e:install": "playwright install chromium",
     "typecheck": "node scripts/typecheck.mjs",
     "verify-migrations": "node scripts/verify-migrations.mjs",
     "verify-baseline": "node scripts/verify-baseline.mjs",
@@ -29,6 +31,7 @@
     "openai": "^4.26.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "concurrently": "^8.2.0"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,35 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Playwright config — minimal harness for OutreachOS e2e tests.
+//
+// PR-A is harness + one auth-page smoke test that runs against any frontend
+// URL. It defaults to the production Vercel deployment so CI works without
+// local infra; override with PLAYWRIGHT_BASE_URL=http://localhost:5173 to
+// develop tests against a locally-running frontend.
+//
+// Browsers must be installed once:
+//   npx playwright install chromium
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  // Each test gets up to 30s. Network calls to prod are slower than local.
+  timeout: 30_000,
+  // Don't bake parallelism in yet — easier to debug a serial run while the
+  // suite is small. Future PRs can enable `fullyParallel: true`.
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'https://outreach-jt.vercel.app',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/tests/e2e/auth.spec.js
+++ b/tests/e2e/auth.spec.js
@@ -1,0 +1,27 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// auth.spec.js — PR-A smoke test.
+//
+// Loads the unauthenticated landing page and asserts the login form is
+// rendered. Doesn't actually sign in — that needs a test account, and PR-A's
+// goal is to prove the harness works end-to-end. Login-flow tests land in
+// PR-B once test-user provisioning is wired up.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { test, expect } from '@playwright/test'
+
+test('landing page shows login form', async ({ page }) => {
+  await page.goto('/')
+
+  // Unique anchors: branding + the password-mode subtitle (default mode).
+  await expect(page.getByText('OutreachOS')).toBeVisible()
+  await expect(page.getByText('Sign in to continue')).toBeVisible()
+
+  // Email + password inputs are interactable.
+  const email = page.getByPlaceholder('you@example.com')
+  await expect(email).toBeVisible()
+  await email.fill('test@example.com')
+  await expect(email).toHaveValue('test@example.com')
+
+  const password = page.getByPlaceholder('••••••••')
+  await expect(password).toBeVisible()
+})


### PR DESCRIPTION
## Summary

PR-A of audit fix #6 — sets up the Playwright e2e harness so future flow tests have a place to slot into. Scope intentionally narrow per scoping discussion: install + config + one test that proves the wiring works.

## What landed

- \`@playwright/test\` as devDependency
- \`playwright.config.js\` — chromium-only, default \`baseURL\` = production Vercel (so CI works without local infra). Override via \`PLAYWRIGHT_BASE_URL\`. retries=2 in CI, 0 locally. trace + screenshot on failure.
- \`tests/e2e/auth.spec.js\` — loads landing page, asserts branding, the password-mode subtitle, and that email + password inputs are rendered and interactable.
- npm scripts:
  - \`npm run test:e2e\` — runs the suite
  - \`npm run test:e2e:install\` — one-time chromium download (~150 MB, not invoked automatically)
- README \"Tests\" section updated.
- \`.gitignore\`: \`test-results/\`, \`playwright-report/\`, \`.playwright/\`.

## Verification

\`\`\`
$ npm run test:e2e
Running 1 test using 1 worker
  ✓  1 [chromium] › tests/e2e/auth.spec.js:12:1 › landing page shows login form (809ms)
  1 passed (1.3s)
\`\`\`

## Out of scope

Queued for follow-up PRs:
- **PR-B (happy paths)**: actual sign-in flow + dashboard / companies / scraper / ranked roles / Auto Apply / outreach. Needs test-user provisioning (Supabase admin API or CI secret).
- **PR-C (edges + mobile)**: error states, viewport switching, two-user isolation (which would also live-verify #9's cross-user fix).
- **CI wiring**: GitHub Actions integration. Local-only for now.

## Notes

- Browsers must be installed once with \`npm run test:e2e:install\` before the first run. Not bundled into \`npm install\` to keep first-time setup fast.
- Default base URL is production. That's fine for smoke tests but means \`test:e2e\` makes real HTTP calls to the live deploy. Set \`PLAYWRIGHT_BASE_URL=http://localhost:5173\` against a local frontend if you want offline runs.