### PR TITLE
fix(profile): match partial unique index in ON CONFLICT clause

### DIFF
--- a/backend/routes/careerOps.js
+++ b/backend/routes/careerOps.js
@@ -278,10 +278,15 @@ router.put('/profile', async (req, res) => {
     }
     if (!cols.length) return res.status(400).json({ error: 'No fields to update' });
     // Upsert on user_id (one row per user). user_id stays out of the SET clause.
+    // The unique index on user_profile.user_id is partial (`WHERE user_id IS
+    // NOT NULL`, from migration 003), so the ON CONFLICT clause must repeat
+    // the predicate for Postgres to recognize it as the conflict target.
+    // See issue #14.
     const sql = `
       INSERT INTO user_profile (user_id, ${cols.join(', ')}, updated_at)
       VALUES ($${userIdPos}, ${placeholders.join(', ')}, NOW())
-      ON CONFLICT (user_id) DO UPDATE SET ${updates.join(', ')}, updated_at = NOW()
+      ON CONFLICT (user_id) WHERE user_id IS NOT NULL
+      DO UPDATE SET ${updates.join(', ')}, updated_at = NOW()
     `;
     await run(sql, args);
     res.json(await one('SELECT * FROM user_profile WHERE user_id = $1', [req.user.id]));


### PR DESCRIPTION
## Summary

Closes #14. \`PUT /api/career/profile\` returns 500 on every write because \`ON CONFLICT (user_id)\` doesn't match the partial unique index from migration 003. One-line SQL fix: add \`WHERE user_id IS NOT NULL\` to the ON CONFLICT clause.

## Repro (pre-fix)

\`\`\`bash
$ curl -X PUT https://outreach-jt.duckdns.org/api/career/profile \\
    -H 'Authorization: Bearer <jwt>' \\
    -H 'Content-Type: application/json' \\
    -d '{"first_name":"Sravya"}'
{"error":"there is no unique or exclusion constraint matching the ON CONFLICT specification"}
\`\`\`

## Why this was hidden

- Founder's profile row was backfilled by migration 003 (\`WHERE id = 1\`) so it already had 40 fields populated.
- Every subsequent edit through this route failed with 500, but the GET still returned the backfilled data, so the UI looked fine on read.
- PR #12's consent gate was the catalyst — running the post-deploy probe was the first time anything actually exercised the UPSERT path with a real JWT against prod since the rollout.

## Why ON CONFLICT (user_id) alone isn't enough

The index from migration 003 is partial:

\`\`\`sql
CREATE UNIQUE INDEX IF NOT EXISTS idx_user_profile_user_id_unique
  ON public.user_profile(user_id) WHERE user_id IS NOT NULL;
\`\`\`

PostgreSQL only accepts a partial index as a conflict target when the \`ON CONFLICT\` predicate matches the index's predicate. So \`ON CONFLICT (user_id) WHERE user_id IS NOT NULL\` resolves; bare \`ON CONFLICT (user_id)\` doesn't.

## Alternative not taken

Migration 008 to convert the partial index into a full UNIQUE constraint (now safe since migration 004 set \`user_id NOT NULL\`). That'd be cleaner schema-wise but mutates production DB. The code fix is reversible and ships in one PR; the schema cleanup can be a follow-up if anyone cares.

## Tests

- Backend tests: 12/12 still pass.
- Live verification post-deploy: re-run \`/tmp/probe-consent.mjs\` with consent in the same request — it should return 200, not 500.

## Out of scope

This is a behavior bug, not a security one. Pre-existing, not introduced by audit fixes #9–#13.