### PR TITLE
test(e2e): PR-B — happy-path coverage + nightly CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,49 @@
+# Nightly Playwright e2e suite against production.
+#
+# Runs at 09:00 UTC daily (≈04:00 ET, when traffic is lowest). Manual runs
+# allowed via workflow_dispatch.
+#
+# Required secret:
+#   E2E_REFRESH_TOKEN — from `node scripts/create-e2e-user.mjs` output.
+#                       Used by tests/e2e/auth.setup.js to mint an access
+#                       token for the shared test account at the start of
+#                       the run.
+
+name: e2e
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install root deps
+        run: npm ci
+
+      - name: Install chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e suite against prod
+        env:
+          E2E_REFRESH_TOKEN: ${{ secrets.E2E_REFRESH_TOKEN }}
+        run: npm run test:e2e
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ __pycache__/
 test-results/
 playwright-report/
 .playwright/
+tests/e2e/.auth/
 
 # OS specific
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ npm run test:e2e          # runs against PLAYWRIGHT_BASE_URL (default: prod Verc
 PLAYWRIGHT_BASE_URL=http://localhost:5173 npm run test:e2e   # local dev
 ```
 
+The authenticated specs need an `E2E_REFRESH_TOKEN` env var. To create the test account once:
+
+```bash
+SUPABASE_URL=https://<ref>.supabase.co \
+SUPABASE_SERVICE_ROLE_KEY=eyJ... \
+node scripts/create-e2e-user.mjs
+# → prints E2E_REFRESH_TOKEN. Add to your local .env and as a GitHub Actions secret.
+```
+
+CI runs the suite nightly (09:00 UTC) via `.github/workflows/e2e.yml`. Manual runs allowed via the GitHub Actions "Run workflow" button.
+
 Frontend build / lint:
 ```bash
 npm run build --prefix frontend

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,23 +1,28 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// Playwright config — minimal harness for OutreachOS e2e tests.
+// Playwright config — OutreachOS e2e tests.
 //
-// PR-A is harness + one auth-page smoke test that runs against any frontend
-// URL. It defaults to the production Vercel deployment so CI works without
-// local infra; override with PLAYWRIGHT_BASE_URL=http://localhost:5173 to
-// develop tests against a locally-running frontend.
+// PR-A landed the harness + landing page smoke test (auth.spec.js).
+// PR-B adds:
+//   - auth.setup.js   — runs once, stashes storageState via Supabase refresh
+//   - 6 happy-path specs that reuse the storageState (chromium-authed project)
 //
-// Browsers must be installed once:
-//   npx playwright install chromium
+// PLAYWRIGHT_BASE_URL overrides the target (default: prod Vercel).
+// E2E_REFRESH_TOKEN is required for any spec under chromium-authed; the
+// chromium project (unauthenticated) runs without it.
+//
+// Browsers: `npm run test:e2e:install` (chromium only).
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { defineConfig, devices } from '@playwright/test'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const STORAGE_PATH = path.join(__dirname, 'tests/e2e/.auth/storage.json')
 
 export default defineConfig({
   testDir: './tests/e2e',
-  // Each test gets up to 30s. Network calls to prod are slower than local.
   timeout: 30_000,
-  // Don't bake parallelism in yet — easier to debug a serial run while the
-  // suite is small. Future PRs can enable `fullyParallel: true`.
   fullyParallel: false,
   retries: process.env.CI ? 2 : 0,
   reporter: [['list']],
@@ -27,9 +32,29 @@ export default defineConfig({
     screenshot: 'only-on-failure',
   },
   projects: [
+    // 1. Setup — runs first, stashes storageState. Skipped if no refresh token.
+    {
+      name: 'setup',
+      testMatch: /auth\.setup\.js/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // 2. Unauthenticated landing-page smoke test (PR-A).
     {
       name: 'chromium',
+      testMatch: /auth\.spec\.js/,
       use: { ...devices['Desktop Chrome'] },
+    },
+
+    // 3. Authenticated specs (PR-B). Reuses storageState produced by `setup`.
+    {
+      name: 'chromium-authed',
+      testIgnore: [/auth\.spec\.js/, /auth\.setup\.js/],
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: STORAGE_PATH,
+      },
+      dependencies: ['setup'],
     },
   ],
 })

--- a/scripts/create-e2e-user.mjs
+++ b/scripts/create-e2e-user.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// ─────────────────────────────────────────────────────────────────────────────
+// create-e2e-user.mjs — one-time setup for the e2e test account.
+//
+// Creates a Supabase auth user via the admin API, signs in as that user, and
+// prints the resulting refresh_token. Add the refresh_token to your local
+// .env (E2E_REFRESH_TOKEN=...) and to the GitHub repo secrets so the nightly
+// CI run can authenticate.
+//
+// Run once. The refresh token rotates on use, so don't share it.
+//
+// Required env:
+//   SUPABASE_URL                — e.g. https://dkifhfqgoremdjhkcojc.supabase.co
+//   SUPABASE_SERVICE_ROLE_KEY   — Project Settings → API → service_role key.
+//                                 NEVER commit this. Use only locally.
+//
+// Optional env:
+//   E2E_TEST_EMAIL    — defaults to e2e+<timestamp>@outreach-os.local
+//   E2E_TEST_PASSWORD — defaults to a strong random string (printed at end)
+//
+// Usage:
+//   SUPABASE_URL=https://… \
+//   SUPABASE_SERVICE_ROLE_KEY=eyJ… \
+//   node scripts/create-e2e-user.mjs
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { randomBytes } from 'node:crypto'
+
+const SUPABASE_URL  = process.env.SUPABASE_URL
+const SERVICE_ROLE  = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!SUPABASE_URL || !SERVICE_ROLE) {
+  console.error('Missing required env: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY')
+  console.error('Find them in Supabase dashboard → Project Settings → API')
+  process.exit(2)
+}
+
+const email    = process.env.E2E_TEST_EMAIL    || `e2e+${Date.now()}@outreach-os.local`
+const password = process.env.E2E_TEST_PASSWORD || randomBytes(24).toString('base64url')
+
+console.log(`Creating test user: ${email}`)
+
+// 1. Admin: create the user (email pre-confirmed).
+const create = await fetch(`${SUPABASE_URL}/auth/v1/admin/users`, {
+  method:  'POST',
+  headers: {
+    'Content-Type':  'application/json',
+    'Authorization': `Bearer ${SERVICE_ROLE}`,
+    'apikey':        SERVICE_ROLE,
+  },
+  body: JSON.stringify({
+    email,
+    password,
+    email_confirm: true,
+  }),
+})
+if (!create.ok) {
+  console.error('admin createUser failed:', create.status, await create.text())
+  process.exit(1)
+}
+const user = await create.json()
+console.log(`✓ Created user id=${user.id}`)
+
+// 2. Sign in as that user via the regular auth endpoint to get a session.
+//    The admin API doesn't return a refresh_token — we have to sign in.
+const signin = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=password`, {
+  method:  'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    // Sign-in uses the anon key as apikey, not the service role.
+    // We don't have anon at hand — but service_role works on /token endpoints
+    // because it has all privileges. Keeping it simple here.
+    'apikey':       SERVICE_ROLE,
+  },
+  body: JSON.stringify({ email, password }),
+})
+if (!signin.ok) {
+  console.error('signin failed:', signin.status, await signin.text())
+  process.exit(1)
+}
+const session = await signin.json()
+
+console.log('\n────────────────────────────────────────')
+console.log('Add to your local .env and GitHub Actions secrets:')
+console.log('────────────────────────────────────────')
+console.log(`E2E_TEST_EMAIL=${email}`)
+console.log(`E2E_TEST_PASSWORD=${password}   # save somewhere safe in case you need to re-sign-in manually`)
+console.log(`E2E_REFRESH_TOKEN=${session.refresh_token}`)
+console.log('────────────────────────────────────────')
+console.log('\nThen run:  npm run test:e2e')

--- a/tests/e2e/auth.setup.js
+++ b/tests/e2e/auth.setup.js
@@ -1,0 +1,57 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// auth.setup.js — runs once before the e2e suite and stashes a logged-in
+// session in storageState. Subsequent specs reuse it via Playwright's
+// dependsOn project relationship (see playwright.config.js).
+//
+// Reads E2E_REFRESH_TOKEN from env. Locally: paste it manually after running
+// scripts/create-e2e-user.mjs once. In CI: GitHub Actions secret.
+//
+// Supabase URL + anon key are public (anon role is intended to be exposed in
+// frontend bundles), so they're hardcoded here. If the project gets recreated,
+// update the constants.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { test as setup, expect } from '@playwright/test'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SUPABASE_URL  = 'https://dkifhfqgoremdjhkcojc.supabase.co'
+const SUPABASE_ANON = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRraWZoZnFnb3JlbWRqaGtjb2pjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY3NzE2OTAsImV4cCI6MjA5MjM0NzY5MH0.IoppGmy8AMU0mqKOrMNB2C60VZXtzcLkZURHoARNLss'
+const STORAGE_KEY   = 'sb-dkifhfqgoremdjhkcojc-auth-token'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const STORAGE_PATH = path.join(__dirname, '.auth', 'storage.json')
+
+setup('refresh session and save storage state', async ({ page }) => {
+  const rt = process.env.E2E_REFRESH_TOKEN
+  if (!rt) {
+    setup.skip(true, 'E2E_REFRESH_TOKEN not set — run scripts/create-e2e-user.mjs first or paste a refresh_token from a browser session.')
+  }
+
+  // Mint a fresh access_token. Refresh tokens rotate, but Playwright caches
+  // storageState per run so we always start with a freshly minted access.
+  const r = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=refresh_token`, {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON },
+    body:    JSON.stringify({ refresh_token: rt }),
+  })
+  if (!r.ok) {
+    throw new Error(`Supabase refresh failed (${r.status}): ${(await r.text()).slice(0, 200)}`)
+  }
+  const session = await r.json()
+
+  // Visit the app once to let it set the supabase client up; then inject the
+  // session into localStorage and persist storage state for downstream specs.
+  await page.goto('/')
+  await page.evaluate(([k, v]) => localStorage.setItem(k, JSON.stringify(v)), [STORAGE_KEY, session])
+
+  // Reload so the supabase client picks up the session and the app routes to
+  // the authenticated layout.
+  await page.reload()
+
+  // Sanity: the dashboard renders something only an authed user sees.
+  // Use a reasonably-stable selector that doesn't depend on data presence.
+  await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 })
+
+  await page.context().storageState({ path: STORAGE_PATH })
+})

--- a/tests/e2e/auto-apply.spec.js
+++ b/tests/e2e/auto-apply.spec.js
@@ -1,0 +1,13 @@
+// Apply → Auto Apply happy-path: page renders, default tab loads, switching
+// to the Queue tab reveals its worker sections.
+import { test, expect } from '@playwright/test'
+
+test('auto-apply page renders + Queue tab shows worker sections', async ({ page }) => {
+  await page.goto('/apply/auto-apply')
+  await expect(page.getByRole('heading', { name: 'Auto Apply', level: 1 })).toBeVisible()
+
+  // Default tab is "setup" — switch to "Queue" to surface the bulk queue + worker.
+  await page.getByRole('button', { name: /queue/i }).first().click()
+  await expect(page.getByRole('heading', { name: 'Bulk Queue Evaluations' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Run Auto-Apply Worker' })).toBeVisible()
+})

--- a/tests/e2e/companies.spec.js
+++ b/tests/e2e/companies.spec.js
@@ -1,0 +1,13 @@
+// Discover → Companies happy-path: page renders + search input is present.
+import { test, expect } from '@playwright/test'
+
+test('companies page renders + search is interactable', async ({ page }) => {
+  await page.goto('/discover/companies')
+  await expect(page.getByRole('heading', { name: 'Companies', level: 1 })).toBeVisible()
+
+  // Search box is the primary affordance — verify it exists and accepts input.
+  const search = page.getByPlaceholder(/search/i).first()
+  await expect(search).toBeVisible()
+  await search.fill('test')
+  await expect(search).toHaveValue('test')
+})

--- a/tests/e2e/dashboard.spec.js
+++ b/tests/e2e/dashboard.spec.js
@@ -1,0 +1,7 @@
+// Dashboard happy-path: page renders for an authenticated user.
+import { test, expect } from '@playwright/test'
+
+test('dashboard renders for authed user', async ({ page }) => {
+  await page.goto('/dashboard')
+  await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible()
+})

--- a/tests/e2e/outreach.spec.js
+++ b/tests/e2e/outreach.spec.js
@@ -1,0 +1,7 @@
+// Outreach → Messages happy-path: contacts page renders.
+import { test, expect } from '@playwright/test'
+
+test('outreach CRM renders', async ({ page }) => {
+  await page.goto('/outreach/messages')
+  await expect(page.getByRole('heading', { name: 'Outreach CRM', level: 1 })).toBeVisible()
+})

--- a/tests/e2e/ranked-roles.spec.js
+++ b/tests/e2e/ranked-roles.spec.js
@@ -1,0 +1,7 @@
+// Apply → Ranked Roles happy-path: Career Ops page renders.
+import { test, expect } from '@playwright/test'
+
+test('ranked roles page (Career Ops) renders', async ({ page }) => {
+  await page.goto('/apply/ranked')
+  await expect(page.getByRole('heading', { name: 'Career Ops', level: 1 })).toBeVisible()
+})

--- a/tests/e2e/scraper.spec.js
+++ b/tests/e2e/scraper.spec.js
@@ -1,0 +1,8 @@
+// Discover → Scraper happy-path: page renders. Doesn't actually run a scrape
+// (Apify quota — saving for PR-C with mocked external calls).
+import { test, expect } from '@playwright/test'
+
+test('scraper page renders', async ({ page }) => {
+  await page.goto('/discover/scraper')
+  await expect(page.getByRole('heading', { name: 'Job Scraper', level: 1 })).toBeVisible()
+})


### PR DESCRIPTION
## Summary

PR-B of audit fix #6 — adds authenticated happy-path coverage and nightly CI on top of PR-A's harness.

## Scoping (locked in earlier this session)

- **Test target**: production Vercel deploy. Tests are read-only — no writes against real data.
- **CI cadence**: nightly cron at 09:00 UTC, no per-PR gate.
- **Test user**: shared static account, refresh token in GitHub Actions secret. Service-role key never enters CI.
- **Test user creation**: scripted via Supabase admin API (\`scripts/create-e2e-user.mjs\`).

## What's in this PR

| File | What |
|---|---|
| \`tests/e2e/auth.setup.js\` | Playwright "setup" project that uses \`E2E_REFRESH_TOKEN\` to mint a fresh access_token, injects it into localStorage, saves storageState. Skips cleanly if env unset. |
| \`tests/e2e/dashboard.spec.js\` | \`/dashboard\` renders for authed user |
| \`tests/e2e/companies.spec.js\` | \`/discover/companies\` renders + search interactable |
| \`tests/e2e/scraper.spec.js\` | \`/discover/scraper\` renders |
| \`tests/e2e/ranked-roles.spec.js\` | \`/apply/ranked\` renders |
| \`tests/e2e/auto-apply.spec.js\` | \`/apply/auto-apply\` renders + Queue tab worker sections appear |
| \`tests/e2e/outreach.spec.js\` | \`/outreach/messages\` renders |
| \`scripts/create-e2e-user.mjs\` | One-time test user creation via Supabase admin API |
| \`.github/workflows/e2e.yml\` | Nightly cron + workflow_dispatch + artifact upload on failure |
| \`playwright.config.js\` | 3 projects: setup / chromium / chromium-authed |
| README + .gitignore | Docs + ignore \`tests/e2e/.auth/\` (storage state with live tokens) |

## Smoke verification

\`\`\`
$ E2E_REFRESH_TOKEN=… npm run test:e2e
Running 8 tests using 5 workers
  ✓ landing page shows login form
  ✓ refresh session and save storage state
  ✓ outreach CRM renders
  ✓ companies page renders + search is interactable
  ✓ ranked roles page (Career Ops) renders
  ✓ dashboard renders for authed user
  ✓ auto-apply page renders + Queue tab shows worker sections
  ✓ scraper page renders
  8 passed (3.0s)
\`\`\`

## What you need to do after merge

1. Run \`scripts/create-e2e-user.mjs\` once locally (needs \`SUPABASE_SERVICE_ROLE_KEY\` in env). It'll print an \`E2E_REFRESH_TOKEN\`.
2. Add \`E2E_REFRESH_TOKEN\` as a **GitHub Actions secret** (Settings → Secrets and variables → Actions → New repository secret).
3. The nightly workflow will run automatically the next 09:00 UTC, or you can trigger it manually via the Actions tab.

If you skip steps 1-2, the workflow runs but \`auth.setup.js\` will skip with a clear message and the authenticated specs will not run.

## Out of scope (queued for PR-C)

- Mobile viewport coverage
- Cross-user isolation tests (would also live-verify #9 + #11 with two real JWTs)
- Write paths (evaluating roles, creating companies) with proper cleanup
- Edge-case + error-state coverage

## Notes

- Anon key + Supabase URL are hardcoded in \`auth.setup.js\` — both are publicly visible (anon role is intentionally exposed in frontend bundles). If the Supabase project is recreated, update the constants.
- Refresh tokens rotate on use, so the storage state captures the latest one. CI uses the stored secret each run; if Supabase ever invalidates a token mid-rotation, regenerate via the script.