### PR TITLE
test(e2e): PR-C — mobile viewport + auth-required regression specs

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -39,19 +39,34 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
 
-    // 2. Unauthenticated landing-page smoke test (PR-A).
+    // 2. Unauthenticated specs: landing-page smoke (PR-A) + the auth-required
+    //    regression suite (PR-C) which probes protected endpoints without
+    //    credentials and asserts 401.
     {
       name: 'chromium',
-      testMatch: /auth\.spec\.js/,
+      testMatch: [/auth\.spec\.js$/, /auth-required\.spec\.js$/],
       use: { ...devices['Desktop Chrome'] },
     },
 
     // 3. Authenticated specs (PR-B). Reuses storageState produced by `setup`.
     {
       name: 'chromium-authed',
-      testIgnore: [/auth\.spec\.js/, /auth\.setup\.js/],
+      testIgnore: [/auth\.spec\.js$/, /auth-required\.spec\.js$/, /auth\.setup\.js$/, /\.mobile\.spec\.js$/],
       use: {
         ...devices['Desktop Chrome'],
+        storageState: STORAGE_PATH,
+      },
+      dependencies: ['setup'],
+    },
+
+    // 4. Mobile viewport (PR-C). Runs only specs ending in .mobile.spec.js
+    //    against a Pixel 7 emulation (chromium-based — keeps the browser
+    //    install footprint small; webkit isn't required).
+    {
+      name: 'mobile-pixel',
+      testMatch: /\.mobile\.spec\.js$/,
+      use: {
+        ...devices['Pixel 7'],
         storageState: STORAGE_PATH,
       },
       dependencies: ['setup'],

--- a/tests/e2e/auth-required.spec.js
+++ b/tests/e2e/auth-required.spec.js
@@ -1,0 +1,45 @@
+// Auth-required regression spec — PR-C of audit fix #6.
+//
+// Asserts that every protected backend endpoint returns 401 when called with
+// no Authorization header. Catches regressions where someone accidentally
+// drops the requireAuth middleware off a route — exactly the gap the audit
+// flagged as Critical when AUTH_MODE was previously 'log-only'.
+//
+// Runs in the `chromium-authed` project but doesn't actually use the
+// authenticated state; it just calls the backend directly via Playwright's
+// request fixture without auth headers.
+import { test, expect } from '@playwright/test'
+
+// Where the backend lives. Lives separately from the frontend baseURL.
+const BACKEND_URL = process.env.E2E_BACKEND_URL || 'https://outreach-jt.duckdns.org'
+
+const PROTECTED = [
+  // Random sample of representative GET endpoints across the API surface.
+  { method: 'GET',  path: '/api/stats' },
+  { method: 'GET',  path: '/api/career/tracker' },
+  { method: 'GET',  path: '/api/career/evaluations' },
+  { method: 'GET',  path: '/api/unified/dashboard' },
+  { method: 'POST', path: '/api/jobs/reclassify-unclassified', body: {} },
+  // Deprecated endpoints from PR #9 — still gated by auth before returning 410.
+  { method: 'GET',  path: '/api/career/tracker/raw' },
+  { method: 'GET',  path: '/api/career/reports' },
+  { method: 'POST', path: '/api/automations/auto-apply', body: { jobs: [], mode: 'review' } },
+]
+
+for (const { method, path, body } of PROTECTED) {
+  test(`unauth ${method} ${path} → 401`, async ({ request }) => {
+    const r = await request.fetch(BACKEND_URL + path, {
+      method,
+      data: body,
+      headers: { 'Content-Type': 'application/json' },
+      // Strip any cookies/headers the request fixture might inherit.
+      failOnStatusCode: false,
+    })
+    expect(r.status(), `${method} ${path} should reject anon callers`).toBe(401)
+  })
+}
+
+test('public endpoint /api/health returns 200 unauth', async ({ request }) => {
+  const r = await request.fetch(BACKEND_URL + '/api/health', { failOnStatusCode: false })
+  expect(r.status()).toBe(200)
+})

--- a/tests/e2e/responsive.mobile.spec.js
+++ b/tests/e2e/responsive.mobile.spec.js
@@ -1,0 +1,26 @@
+// Mobile viewport coverage — PR-C of audit fix #6.
+//
+// Runs in the `mobile-iphone` Playwright project (iPhone 13 emulation).
+// Asserts that key pages render without horizontal overflow and that the
+// primary heading is still visible at mobile width.
+import { test, expect } from '@playwright/test'
+
+const ROUTES = [
+  { path: '/dashboard',          heading: 'Dashboard' },
+  { path: '/discover/companies', heading: 'Companies' },
+  { path: '/apply/auto-apply',   heading: 'Auto Apply' },
+]
+
+for (const { path, heading } of ROUTES) {
+  test(`mobile: ${path} renders without horizontal scroll`, async ({ page }) => {
+    await page.goto(path)
+    await expect(page.getByRole('heading', { name: heading, level: 1 })).toBeVisible()
+
+    // No content should overflow the viewport horizontally — that's the
+    // single most common mobile regression in inline-style-heavy components.
+    const overflow = await page.evaluate(() => {
+      return document.documentElement.scrollWidth - document.documentElement.clientWidth
+    })
+    expect(overflow, `${path} has ${overflow}px of horizontal overflow`).toBeLessThanOrEqual(0)
+  })
+}


### PR DESCRIPTION
## Summary

PR-C of audit fix #6. Tighter than originally scoped — ships the two highest-leverage slices and defers the rest:

✅ **Mobile viewport coverage** — Pixel 7 emulation, asserts no horizontal scroll overflow on the three most layout-sensitive routes (\`/dashboard\`, \`/discover/companies\`, \`/apply/auto-apply\`). Pixel-based intentionally — chromium-only browser install stays.

✅ **Auth-required regression spec** — probes 7 protected endpoints with no Authorization header and asserts 401. Catches future regressions where someone accidentally drops requireAuth off a route. Also asserts \`/api/health\` stays publicly accessible.

⏳ **Deferred to PR-D**:
- Two-user cross-isolation tests (would also live-verify #9 + #11 with two real JWTs). Needs a second test account + refresh token + script extension.
- Write-path tests (creating evaluations / companies) with proper cleanup. Needs a non-prod test environment to avoid contaminating real data.
- Generic edge-case + error-state coverage.

## Files

| Path | Purpose |
|---|---|
| \`playwright.config.js\` | Adds \`mobile-pixel\` project; \`chromium\` project now matches both \`auth.spec.js\` and \`auth-required.spec.js\` (no storageState — testing the unauth path). |
| \`tests/e2e/responsive.mobile.spec.js\` | 3 mobile-viewport tests, one per route. |
| \`tests/e2e/auth-required.spec.js\` | 7 unauth-401 + 1 unauth-200-on-health. |

## Verification

\`\`\`
$ E2E_REFRESH_TOKEN=… npm run test:e2e
Running 20 tests using 5 workers
  ✓ landing page shows login form
  ✓ refresh session and save storage state
  ✓ unauth GET /api/stats → 401
  ✓ unauth GET /api/career/tracker → 401
  ✓ unauth GET /api/career/evaluations → 401
  ✓ unauth GET /api/unified/dashboard → 401
  ✓ unauth POST /api/jobs/reclassify-unclassified → 401
  ✓ unauth GET /api/career/tracker/raw → 401
  ✓ unauth GET /api/career/reports → 401
  ✓ unauth POST /api/automations/auto-apply → 401
  ✓ public endpoint /api/health returns 200 unauth
  ✓ dashboard renders for authed user
  ✓ outreach CRM renders
  ✓ companies page renders + search is interactable
  ✓ ranked roles page (Career Ops) renders
  ✓ auto-apply page renders + Queue tab shows worker sections
  ✓ scraper page renders
  ✓ mobile: /dashboard renders without horizontal scroll
  ✓ mobile: /discover/companies renders without horizontal scroll
  ✓ mobile: /apply/auto-apply renders without horizontal scroll
  20 passed (5.7s)
\`\`\`

After merge, the nightly CI run will pick these up automatically — same workflow file, no infra changes needed.

## Notes

- The mobile spec uses a runtime-computed \`scrollWidth - clientWidth\` check rather than a screenshot-diff. Catches actual layout breakage without the noise of pixel-perfect comparisons.
- The auth-required spec uses Playwright's \`request\` fixture (HTTP only, no browser context) which doesn't inherit storageState cookies. The Authorization header is the auth surface, and we never set it.