### PR TITLE
test(e2e): PR-D — edge-case routing tests

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -41,17 +41,17 @@ export default defineConfig({
 
     // 2. Unauthenticated specs: landing-page smoke (PR-A) + the auth-required
     //    regression suite (PR-C) which probes protected endpoints without
-    //    credentials and asserts 401.
+    //    credentials and asserts 401, plus PR-D edge-case routing.
     {
       name: 'chromium',
-      testMatch: [/auth\.spec\.js$/, /auth-required\.spec\.js$/],
+      testMatch: [/auth\.spec\.js$/, /auth-required\.spec\.js$/, /edge-cases\.spec\.js$/],
       use: { ...devices['Desktop Chrome'] },
     },
 
-    // 3. Authenticated specs (PR-B). Reuses storageState produced by `setup`.
+    // 3. Authenticated specs (PR-B + PR-D edge-cases-authed). Reuses storageState.
     {
       name: 'chromium-authed',
-      testIgnore: [/auth\.spec\.js$/, /auth-required\.spec\.js$/, /auth\.setup\.js$/, /\.mobile\.spec\.js$/],
+      testIgnore: [/auth\.spec\.js$/, /auth-required\.spec\.js$/, /^.*edge-cases\.spec\.js$/, /auth\.setup\.js$/, /\.mobile\.spec\.js$/],
       use: {
         ...devices['Desktop Chrome'],
         storageState: STORAGE_PATH,

--- a/tests/e2e/edge-cases-authed.spec.js
+++ b/tests/e2e/edge-cases-authed.spec.js
@@ -1,0 +1,12 @@
+// Edge-case routing for an authenticated session — PR-D of audit fix #6.
+//
+// Runs in the `chromium-authed` project. Confirms the catch-all route
+// redirects unknown paths to /dashboard while logged in, instead of
+// rendering a 404 page or the login form.
+import { test, expect } from '@playwright/test'
+
+test('unknown URL redirects to /dashboard when authenticated', async ({ page }) => {
+  await page.goto('/this-route-does-not-exist')
+  await expect(page).toHaveURL(/\/dashboard/, { timeout: 5_000 })
+  await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible()
+})

--- a/tests/e2e/edge-cases.spec.js
+++ b/tests/e2e/edge-cases.spec.js
@@ -1,0 +1,21 @@
+// Edge-case routing — PR-D of audit fix #6.
+//
+// Runs in the unauthenticated `chromium` project: confirms unknown URLs
+// route via the catch-all and that protected routes show the login form
+// when no session is present.
+import { test, expect } from '@playwright/test'
+
+test('unknown URL falls through the catch-all', async ({ page }) => {
+  await page.goto('/this-route-does-not-exist')
+  // Catch-all is <Route path="*" element={<Navigate to="/dashboard" />}>.
+  // Without a session the dashboard renders <Login />, so we verify by the
+  // login form rather than the URL — the URL flow can race with the redirect.
+  await expect(page.getByText('OutreachOS')).toBeVisible()
+  await expect(page.getByText('Sign in to continue')).toBeVisible()
+})
+
+test('direct nav to a protected route while unauth renders the login form', async ({ page }) => {
+  await page.goto('/discover/companies')
+  await expect(page.getByText('OutreachOS')).toBeVisible()
+  await expect(page.getByText('Sign in to continue')).toBeVisible()
+})


### PR DESCRIPTION
## Summary

PR-D-lite. Adds two edge-case specs covering SPA routing transitions that the happy-path suite doesn't exercise.

## What's in this PR

| Spec | Project | Asserts |
|---|---|---|
| \`tests/e2e/edge-cases.spec.js\` | \`chromium\` (unauth) | \`/this-route-does-not-exist\` falls through the App.jsx \`*\` route and shows the login form (since no session); direct nav to a protected route while unauth shows the login form. |
| \`tests/e2e/edge-cases-authed.spec.js\` | \`chromium-authed\` | \`/this-route-does-not-exist\` redirects to \`/dashboard\` and the Dashboard heading is visible. |

Together these catch two regressions you'd otherwise only notice manually:
1. The App.jsx catch-all (\`<Route path="*" element={<Navigate to="/dashboard" />}\`) silently breaking.
2. A protected route accidentally rendering past the \`!session\` gate.

## Verification

\`\`\`
$ E2E_REFRESH_TOKEN=… npm run test:e2e
Running 23 tests using 5 workers
  …
  23 passed (6.1s)
\`\`\`

## Still deferred (PR-E or later)

- **Two-user cross-isolation tests** — would live-verify the cross-user fix from #9 + #11 with two real JWTs. Needs a second admin-API-created test user, a second \`E2E_REFRESH_TOKEN_USER_B\` GitHub secret, and an extra Playwright project. ~1h of plumbing on top of what's here. Worth its own PR.
- **Write-path tests with cleanup** — requires either a dedicated staging Supabase project or in-test cleanup using admin API. Both have infra implications.

## Notes

- The unauth edge-case spec uses text matching ("OutreachOS", "Sign in to continue") to detect the login form rather than checking URL state. The catch-all redirect can race with the page render, so URL-based assertions are flaky; the visible form is the source of truth.
- After merge, the nightly CI run picks these up automatically — no workflow changes needed.